### PR TITLE
- backup config keeps being valid now if source dataset is renamed

### DIFF
--- a/lib/ZnapZend/Time.pm
+++ b/lib/ZnapZend/Time.pm
@@ -222,7 +222,7 @@ sub checkTimeFormat {
     my $self = shift;
     my $timeFormat = shift;
 
-    $timeFormat =~ /^(?:%[YmdHMS]|[-_.:])+$/ or die "ERROR: timestamp format not valid. check your syntax\n";
+    $timeFormat =~ /^(?:%[YmdHMS]|[\w\-.:])+$/ or die "ERROR: timestamp format not valid. check your syntax\n";
 
     #just a made-up time to check if strftime and strptime work
     my $timeToCheck = gmtime(1014416542);

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -330,6 +330,9 @@ sub setDataSetProperties {
     return 0 if !$self->dataSetExists($dataSet);
 
     for my $prop (keys %$properties){
+        #don't save source dataset as we know the source from the property location
+        next if $prop eq 'src';
+
         my @cmd = (qw(zfs set), "$propertyPrefix:$prop=$properties->{$prop}", $dataSet);
         print STDERR '# ' . join(' ', @cmd) . "\n" if $self->debug;
         system(@cmd) && die "ERROR: could not set property $prop on $dataSet\n" if !$self->noaction;


### PR DESCRIPTION
source datasets can now be renamed whilst keeping backup config vaild.
