### PR TITLE
SMF manifest fixes

### DIFF
--- a/init/znapzend.xml.in
+++ b/init/znapzend.xml.in
@@ -28,7 +28,7 @@
         <exec_method 
                 type="method" 
                 name="start" 
-                exec="@prefix@/bin/znapzend --daemonize --pidfile=/dev/null"
+                exec="@exec_prefix@/bin/znapzend --daemonize --pidfile=/dev/null"
                 timeout_seconds="170" />
 
         <exec_method
@@ -48,9 +48,9 @@
                 </loctext>
             </common_name>
             <documentation>
-                <manpage title="znapzend" section="1" manpath="@prefix@/share/man" />
-                <manpage title="znapzendzetup" section="1" manpath="@prefix@/share/man" />
-                <manpage title="znapzendztatz" section="1" manpath="@prefix@/share/man" />
+                <manpage title="znapzend" section="1" manpath="@mandir@" />
+                <manpage title="znapzendzetup" section="1" manpath="@mandir@" />
+                <manpage title="znapzendztatz" section="1" manpath="@mandir@" />
             </documentation>
         </template>
 </service>


### PR DESCRIPTION
There's no need to track the daemon's pid, SMF does that for us. Additionally the binary is not under prefix, it is under exec_prefix (by the assumptions I noted in #102), and we can also do a better job with mandir.
