### PR TITLE
Include note on lower-case requirement for DST fields

### DIFF
--- a/doc/znapzendzetup.pod
+++ b/doc/znapzendzetup.pod
@@ -82,7 +82,9 @@ To keep one copy every two days for 10 years:
 In a minimal setup, you just specify a plan for the B<SRC> fileset. This
 will cause snapshots to be taken and destroyed according to the plan. You
 can then add one or several destinations (B<DST>) both local (preferably on
-a different pool) or remote.
+a different pool) or remote. Please be aware that only lower-case-letters 
+are allowed for the (B<DST>) names (eg. in case you want to name the (B<DST>)
+like a mixed-case named pool you might have).
 
 When adding multiple B<DST> entries, each will get labled for later
 identification, optionally you can specify your own label.


### PR DESCRIPTION
- Added a little sentence to clarify that DST names can only contain lower-case letters