### PR TITLE
Fix sudo/pfexec use when querying config.

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -42,7 +42,8 @@ has backupSets       => sub { [] };
 
 has zConfig => sub {
     my $self = shift;
-    ZnapZend::Config->new(debug => $self->debug, noaction => $self->noaction);
+    ZnapZend::Config->new(debug => $self->debug, noaction => $self->noaction,
+                          pfexec => $self->pfexec, sudo => $self->sudo);
 };
 
 has zZfs => sub {


### PR DESCRIPTION
`refreshBackupPlans` calls `$self->zConfig->getBackupSetEnabled($dataSet)`
but `zConfig` was not initialised with sudo/pfexec features and hence
there were errors calling the `zfs` command.