### PR TITLE
Create datasets on dst when it doesn't exist

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -67,6 +67,7 @@ B<znapzend> [I<options>...]
  --runonce=x        run one round on source dataset x
  --features=x       comma separated list of features to be enabled
  --connectTimeout=x sets the ConnectTimeout for ssh commands
+ --autoCreation     automatically create dataset on dest if it not exists
 
 =head1 DESCRIPTION
 
@@ -167,6 +168,10 @@ use 'sudo' for zfs commands (e.g. when running znapzend as non-priviledged user)
 =item B<--connectTimeout>=I<timeout>
 
 sets the ssh connection timeout (in seconds)
+
+=item B<--autoCreation>
+
+Automatically create a dataset on a destination host if it's not there yet.
 
 =back
 

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -13,7 +13,7 @@ my %featureMap = map { $_ => 1 } qw(oracleMode recvu pfexec sudo);
 
 sub main {
     GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s),
-        qw(daemonize pidfile=s logto=s loglevel=s runonce=s connectTimeout=s)) or exit 1;
+        qw(daemonize pidfile=s logto=s loglevel=s runonce=s connectTimeout=s autoCreation)) or exit 1;
 
     #split all features into individual options
     if ($opts->{features}){

--- a/doc/znapzend.pod
+++ b/doc/znapzend.pod
@@ -18,6 +18,7 @@ B<znapzend> [I<options>...]
  --runonce=x        run one round on source dataset x
  --features=x       comma separated list of features to be enabled
  --connectTimeout=x sets the ConnectTimeout for ssh commands
+ --autoCreation     automatically create dataset on dest if it not exists
 
 =head1 DESCRIPTION
 
@@ -118,6 +119,10 @@ use 'sudo' for zfs commands (e.g. when running znapzend as non-priviledged user)
 =item B<--connectTimeout>=I<timeout>
 
 sets the ssh connection timeout (in seconds)
+
+=item B<--autoCreation>
+
+Automatically create a dataset on a destination host if it's not there yet.
 
 =back
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -37,6 +37,7 @@ has logto           => sub { q{} };
 has pidfile         => sub { q{} };
 has defaultPidFile  => sub { q{/var/run/znapzend.pid} };
 has terminate       => sub { 0 };
+has autoCreation    => sub { 0 };
 
 has backupSets       => sub { [] };
 
@@ -52,8 +53,7 @@ has zZfs => sub {
         nodestroy => $self->nodestroy, oracleMode => $self->oracleMode,
         recvu => $self->recvu, connectTimeout => $self->connectTimeout,
         pfexec => $self->pfexec, sudo => $self->sudo,
-        zLog => $self->zLog);
-        
+        zLog => $self->zLog, autoCreation => $self->autoCreation);
 };
 
 has zTime => sub { ZnapZend::Time->new() };

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -653,6 +653,10 @@ checks if the dataset exists on localhost or a remote host
 
 checks if the snapshot exists on localhost or a remote host
 
+=head2 createDataSet
+
+creates a dataset on localhost or a remote host
+
 =head2 listDataSets
 
 lists datasets on (remote-)host

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -314,9 +314,13 @@ sub sendRecvSnapshots {
     #attemp a creation of the dataset when it doesn't exist
     $dstDataSetExists = $self->createDataSet($dstDataSet) if $self->autoCreation && !$dstDataSetExists;
 
+    ($remote, $dstDataSet) = $splitHostDataSet->($dstDataSet);
+
     #check if the dstDataSet exist on the destination (maybe after a creation)
     !$dstDataSetExists
-        and Mojo::Exception->throw('ERROR: dstDataSet does not exist on dest host');
+        and Mojo::Exception->throw("ERROR: dataset ($dstDataSet) does not exist on "
+	    . "destination ($remote), use --autoCreation to "
+	    . "let ZnapZend auto create datasets");
 
     my ($lastSnapshot, $lastCommon)
         = $self->lastAndCommonSnapshots($srcDataSet, $dstDataSet, $snapFilter);
@@ -331,7 +335,6 @@ sub sendRecvSnapshots {
             . "found on source and destination "
             . "clean up destination $dstDataSet (i.e. destroy existing snapshots)");
 
-    ($remote, $dstDataSet) = $splitHostDataSet->($dstDataSet);
     ($mbuffer, $mbufferPort) = split /:/, $mbuffer, 2;
 
     my @cmd;

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -318,9 +318,9 @@ sub sendRecvSnapshots {
 
     #check if the dstDataSet exist on the destination (maybe after a creation)
     !$dstDataSetExists
-        and Mojo::Exception->throw("ERROR: dataset ($dstDataSet) does not exist on "
-	    . "destination ($remote), use --autoCreation to "
-	    . "let ZnapZend auto create datasets");
+        and Mojo::Exception->throw("ERROR: dataset ($dstDataSet) does not exist"
+	    .  ($remote ? " on destination ($remote)" : '') .", use --autoCreation "
+	    . "to let ZnapZend auto create datasets");
 
     my ($lastSnapshot, $lastCommon)
         = $self->lastAndCommonSnapshots($srcDataSet, $dstDataSet, $snapFilter);

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -128,23 +128,18 @@ sub createDataSet {
     my $dataSet = shift;
     my $remote;
 
-    #just in case if someone aks to check '';
-    return 0 if !$dataSet;
-
     ($remote, $dataSet) = $splitHostDataSet->($dataSet);
     my @ssh = $self->$buildRemote($remote,
         [@{$self->priv}, qw(zfs create), $dataSet]);
 
     print STDERR '# ' . join(' ', @ssh) . "\n" if $self->debug;
 
-    #return if 'noaction' or snapshot creation successful
+    $self->zLog->info("create new dataset ($dataSet) on destination ($remote)");
+
+    #return if 'noaction' or dataset creation successful
     return 1 if $self->noaction || !system(@ssh);
 
-    #check if snapshot already exists and therefore creation failed
-    return 0 if $self->dataSetExists($dataSet);
-
-    #creation failed and snapshot does not exist, throw an exception
-    Mojo::Exception->throw("ERROR: cannot create dataSet $dataSet");
+    Mojo::Exception->throw("ERROR: failed to create new dataset ($dataSet)");
 }
 
 sub listDataSets {


### PR DESCRIPTION
It checks f the `$dstDataSet` exists, if not, it attempts to create it. When creation is succes, the script continues. When it fails, the script stops and continues to the next dataset.

A new `--autoCreation` option is introduced to enable this feature. It's behavior is disabled by default.