### PR TITLE
Add missing step to checkinstall README

### DIFF
--- a/packaging/checkinstall/README.md
+++ b/packaging/checkinstall/README.md
@@ -7,5 +7,6 @@ You can create a package to install (useful for multiple hosts) with _checkinsta
 cd /tmp/
 git clone https://github.com/oetiker/znapzend
 # git checkout 0.xx.yy
+cd znapzend
 packaging/checkinstall/checkinstall.sh
 ```

--- a/packaging/checkinstall/checkinstall.sh
+++ b/packaging/checkinstall/checkinstall.sh
@@ -1,8 +1,25 @@
 #!/bin/bash
 
+# Exit when encountering an undefined variable
+set -u
+
+# Determine the Ubuntu version we are running on. Versions before
+# 16.04 had a package called zfsutils, from 16.04 onwards the package
+# is called zfsutils-linux
+DistroMajorVersion=$(lsb_release -r |cut -f2 | cut -d. -f1)
+DistroMinorVersion=$(lsb_release -r |cut -f2 | cut -d. -f2)
+if [ ${DistroMajorVersion} -ge 16 ] && [ ${DistroMinorVersion} -ge 4 ]; then
+    zfsutilsdep="zfsutils-linux"
+else
+    zfsutilsdep="zfsutils"
+fi
+
+# Compile znapzend
 make clean
 ./configure --prefix=/usr
 make
+
+# Create the package
 ln -s packaging/checkinstall/*-pak .
-sudo checkinstall --install=no --pkgname=znapzend --pkgversion=$(git describe --abbrev=0 --tags | sed 's,^v,,') --pkglicense=GPL --pkgrelease=1 --pkgsource="https://github.com/oetiker/znapzend" --requires="zfsutils,mbuffer" --provides=znapzend --nodoc --backup=no
+sudo checkinstall --install=no --pkgname=znapzend --pkgversion=$(git describe --abbrev=0 --tags | sed 's,^v,,') --pkglicense=GPL --pkgrelease=1 --pkgsource="https://github.com/oetiker/znapzend" --requires="${zfsutilsdep},mbuffer" --provides=znapzend --nodoc --backup=no
 rm -f *-pak


### PR DESCRIPTION
After cloning the Git repo, the clone is located in the `znapzend` directory, so the user should first `cd` into it before running the checkinstall script.