### PR TITLE
adds link to debian packaging files to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ system PATH.
 for x in /opt/znapzend-0.15.7/bin/*; do ln -s $x /usr/local/bin; done
 ```
 
+Debian packages
+---------------
+
+Debian control files, guide on using them and experimental debian packages can be found at https://github.com/Gregy/znapzend-debian
+
+
 Configuration
 -------------
 


### PR DESCRIPTION
Debian packaging files are in separate repository to ease the work of potential official maintainer.