### PR TITLE
Changed SMF dependency to multi-user

### DIFF
--- a/init/znapzend.xml.in
+++ b/init/znapzend.xml.in
@@ -17,7 +17,7 @@
                 grouping='require_all'
                 restart_on='none'
                 type='service'>
-                <service_fmri value='svc:/milestone/sysconfig' />
+                <service_fmri value='svc:/milestone/multi-user' />
         </dependency>
 
         <method_context>


### PR DESCRIPTION
znapzend starts too early in case of ZFS over iSCSI with delayed zpool import.