### PR TITLE
Fix trivial typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ ZnapZend 0.16.0
 e)
 
 ZnapZend is a ZFS centric backup tool. It relies on snapshot, send and
-receive todo its work. It has the built-in ability to manage both local
-snapshots as well as remote copies by thining them out as time progresses.
+receive to do its work. It has the built-in ability to manage both local
+snapshots as well as remote copies by thinning them out as time progresses.
 
 The ZnapZend configuration is stored as properties in the ZFS filesystem
 itself.

--- a/doc/znapzend.pod
+++ b/doc/znapzend.pod
@@ -36,7 +36,7 @@ talk a lot while running. Sends debug messages to stderr.
 
 =item B<-n>, B<--noaction>
 
-don't do any actions which have lasting effect. Ideal to try our new new
+don't do any actions which have lasting effect. Ideal to try our new
 configurations together with B<--debug>
 
 =item B<--nodestroy>
@@ -46,7 +46,7 @@ do all changes to the filesystem except destroy old snapshots
 =item B<--logto>={B<syslog::>I<facility>|I<filepath>}
 
 send logs out to either syslog or a logfile. Default is to send logs to
-B<syslog::daemon> when runing daemonized. When running in debug mode, the
+B<syslog::daemon> when running daemonized. When running in debug mode, the
 logs will go to STDERR by default.
 
 Examples:
@@ -97,7 +97,7 @@ them individually.
 
 Sometimes a snapshot can not be destroyed because of some oracle zfs bug.
 Only a reeboot seems to be able to fix this. So we just destroy the ones we
-can destroy. Logging an error about the problem
+can destroy. Log an error about the problem
 
 =back
 

--- a/doc/znapzendzetup.pod
+++ b/doc/znapzendzetup.pod
@@ -47,7 +47,7 @@ where 'command' is one of the following:
 
 =head1 DESCRIPTION
 
-Use znapzendsetup to configure your backup tasks. The cli is modled after
+Use znapzendsetup to configure your backup tasks. The cli is modeled after
 the zfs commandline.
 
 After modifying the configuration, send a HUP signal to your znapzend daemon
@@ -61,7 +61,7 @@ The heart of the znapzend backup is the plan. The plan specifies how often
 to backup and for how long to keep the backups. A plan is required both for
 the source and the destination datasets.
 
-The plan consists of a series of retention periodes to interval
+The plan consists of a series of retention periods to interval
 associations:
 
   retA=>intA,retB=>intB,...
@@ -91,7 +91,7 @@ will cause snapshots to be taken and destroyed according to the plan. You
 can then add one or several destinations (B<DST>) both local (preferably on
 a different pool) or remote.
 
-When adding multiple B<DST> entries, each will get labled for later
+When adding multiple B<DST> entries, each will get labeled for later
 identification, optionally you can specify your own label.
 
 =over
@@ -127,9 +127,9 @@ Specify the path to your copy of the mbuffer utility.
 
 =item B<--mbuffer>=I</usr/bin/mbuffer:31337>
 
-Specifiy the path to your copy of the mbuffer utility and the port used
+Specify the path to your copy of the mbuffer utility and the port used
 on the destination. Caution: znapzend will send the data directly
-from source mbuffer to destination mbuffer, thus data stream is B<not>
+from source mbuffer to destination mbuffer, this data stream is B<not>
 encrypted.
 
 =item B<--mbuffersize>=I<number>{B<b>|B<k>|B<M>|B<G>}
@@ -160,7 +160,7 @@ If you deal with a mariadb/mysql database, you can use
   pre-snap-command  = /opt/oep/mariadb/bin/mysql -e "set autocommit=0;flush tables with read lock;\\! /bin/sleep 600" &  /usr/bin/echo $! > /tmp/mariadblock.pid ; sleep 10
   post-snap-command = /usr/bin/kill `/usr/bin/cat /tmp/mariadblock.pid`;/usr/bin/rm /tmp/mariadblock.pid
   
-to make sure that the on-disk data is consistant when snapshotting. Since the
+to make sure that the on-disk data is consistent when snapshotting. Since the
 lock stays only in place for the duration of the connection to mysql
 we need to employ. For this to work, add the root password of your mariadb/mysql db
 setup into ~root/.my.cnf and make sure the file permissions are tight ...
@@ -183,14 +183,14 @@ the B<delete> function understands the following options
 
 =item B<--dst>=I<key>
 
-to only remove a destination, specify the key of the destionation. Use the
+to only remove a destination, specify the key of the destination. Use the
 B<list> function to see the keys.
 
 =back
 
 =head2 B<edit>
 
-modify the configuration of a dataset. see the descriptions in the B<create>
+modify the configuration of a dataset. See the descriptions in the B<create>
 function for details.
 
 If B<edit> is used with a source dataset as single argument, properties
@@ -204,7 +204,7 @@ dumps the backup configuration of a dataset
 
 =head2 B<import>
 
-reads configuration data from a file or STDIN and prints it content
+reads configuration data from a file or STDIN and prints its content
 
 =over
 


### PR DESCRIPTION
Just a bunch of typos in the docs.