### PR TITLE
cleanup gitter link from referral url source param

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ ZnapZend 0.16.0
 
 [![Build Status](https://travis-ci.org/oetiker/znapzend.svg?branch=master)](https://travis-ci.org/oetiker/znapzend)
 [![Coverage Status](https://img.shields.io/coveralls/oetiker/znapzend.svg)](https://coveralls.io/r/oetiker/znapzend?branch=master)
-[![Gitter](https://badges.gitter.im/oetiker/znapzend.svg)](https://gitter.im/oetiker/znapzend?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=body_badg
-e)
+[![Gitter](https://badges.gitter.im/oetiker/znapzend.svg)](https://gitter.im/oetiker/znapzend)
 
 ZnapZend is a ZFS centric backup tool. It relies on snapshot, send and
 receive to do its work. It has the built-in ability to manage both local


### PR DESCRIPTION
The URL previously contained referrer parameters. I cleaned it up so it doesn’t contain that anymore.

Signed-off-by: Justin Scholz <git@justinscholz.de>