### PR TITLE
Makes daemon continue even if there are no enabled backup sets

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -127,7 +127,7 @@ my $refreshBackupPlans = sub {
     $self->backupSets($self->zConfig->getBackupSetEnabled($dataSet));
 
     @{$self->backupSets}
-        or die "ERROR: no backup set defined or enabled, yet. run 'znapzendzetup' to setup znapzend\n";
+        or $self->zLog->warn("No backup set defined or enabled, yet. run 'znapzendzetup' to setup znapzend");
 
     for my $backupSet (@{$self->backupSets}){
         $backupSet->{srcPlanHash} = $self->zTime->backupPlanToHash($backupSet->{src_plan});


### PR DESCRIPTION
Hi,
this PR relates to #253 . It makes the daemon continue running even if there are no backups defined.

I have never touched perl code before but this change seems really simple. All tests are passing and manual testing shows desired behavior.

Thank you