### PR TITLE
Added command line parameter --maxParallelism=i for limiting number of active workers to i. Defaults to 20.

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -13,7 +13,7 @@ my %featureMap = map { $_ => 1 } qw(oracleMode recvu pfexec sudo compressed);
 
 sub main {
     GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s),
-        qw(daemonize pidfile=s logto=s loglevel=s runonce=s connectTimeout=s timeWarp=i autoCreation)) or exit 1;
+        qw(daemonize pidfile=s logto=s loglevel=s runonce=s connectTimeout=s timeWarp=i maxParallelism=i autoCreation)) or exit 1;
 
     #split all features into individual options
     if ($opts->{features}){
@@ -69,6 +69,7 @@ B<znapzend> [I<options>...]
  --connectTimeout=x sets the ConnectTimeout for ssh commands
  --autoCreation     automatically create dataset on dest if it not exists
  --timeWarp=x       shift znapzends sens of NOW into the future by x seconds
+ --maxParallelism=x limit the number of active workers to x; default is 20
  
 =head1 DESCRIPTION
 
@@ -190,6 +191,16 @@ Shift ZnapZends sense of time into the future by x seconds.
 The practical application if this function is to determine what will happen at some future point in time.
 This can be useful for testing but also when running in noaction and debug mode to determine which
 snapshots would be created and removed at some future point in time.
+
+=back
+
+=item B<--maxParallelism>=x
+
+Limits the number of active worker processes to x.
+
+Both snapshotting and sending snapshots to destination creates a separate process for every backup set.
+Using maxParallelism you can set the maximal number of active processes to prevent overload of the server
+running znapzend. Default limit is 20.
 
 =back
 

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -1,4 +1,13 @@
 #!/usr/bin/env perl
+#
+# This is a custom modification of znapzend that was rejected from upstream
+# for using perl core module IPC::SysV and IPC::Semaphore.
+# It adds parameter --maxParallelism=<default 2> for limiting worker processes.
+# The default value was set so low on purpose -- we need it that way and anyone
+# can use their own value.
+#
+# pmares@sic.cz, https://github.com/pmar5303/znapzend
+#
 
 use lib qw(); # PERL5LIB
 use FindBin; use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../thirdparty/lib/perl5"; # LIBDIR
@@ -69,7 +78,7 @@ B<znapzend> [I<options>...]
  --connectTimeout=x sets the ConnectTimeout for ssh commands
  --autoCreation     automatically create dataset on dest if it not exists
  --timeWarp=x       shift znapzends sens of NOW into the future by x seconds
- --maxParallelism=x limit the number of active workers to x; default is 20
+ --maxParallelism=x limit the number of active workers to x; default is 2
  
 =head1 DESCRIPTION
 
@@ -200,7 +209,7 @@ Limits the number of active worker processes to x.
 
 Both snapshotting and sending snapshots to destination creates a separate process for every backup set.
 Using maxParallelism you can set the maximal number of active processes to prevent overload of the server
-running znapzend. Default limit is 20.
+running znapzend. Default limit is 2.
 
 =back
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -45,7 +45,7 @@ has defaultPidFile  => sub { q{/var/run/znapzend.pid} };
 has terminate       => sub { 0 };
 has autoCreation    => sub { 0 };
 has timeWarp        => sub { undef };
-has maxParallelism  => sub { 20 };
+has maxParallelism  => sub { 2 };
 has backupSets      => sub { [] };
 
 has zConfig => sub {

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -11,7 +11,7 @@ has noaction       => sub { 0 };
 has pfexec         => sub { 0 };
 has sudo           => sub { 0 };
 has timeWarp       => sub { undef };
-has maxParallelism => sub { 20 };
+has maxParallelism => sub { 2 };
 
 #mandatory properties
 has mandProperties => sub {

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -6,11 +6,12 @@ use ZnapZend::Time;
 use Text::ParseWords qw(shellwords);
 
 ### attributes ###
-has debug    => sub { 0 };
-has noaction => sub { 0 };
-has pfexec   => sub { 0 };
-has sudo     => sub { 0 };
-has timeWarp => sub { undef };
+has debug          => sub { 0 };
+has noaction       => sub { 0 };
+has pfexec         => sub { 0 };
+has sudo           => sub { 0 };
+has timeWarp       => sub { undef };
+has maxParallelism => sub { 20 };
 
 #mandatory properties
 has mandProperties => sub {


### PR DESCRIPTION
Added command line parameter --maxParallelism=i for limiting the number of active workers. Defaults to 20. Debug-level logging now shows operations with semaphore that is used for concurrency control.
I also updated description in bin/znapzend.

I have tested the changes in Debian Jessie. It is advisable to test it on non-linux platforms.

I haven't followed the suggestions for development and I have not manually run configure or make. I have successfully used the debian-znapzend by Petr Gregor to create deb package.

I stress that I haven't changed the following files:
* VERSION
* CHANGES
* doc/znapzend.pod (it seems description of some old features is missing there)
* t/znapzend.t
* PERL_MODULES

I would need an assistance if I were to change these files.
