### PR TITLE
Fix Mojo::Util::slurp is DEPRECATED

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -2,7 +2,8 @@ package ZnapZend;
 
 use Mojo::Base -base;
 use Mojo::IOLoop::ForkCall;
-use Mojo::Util qw(slurp);
+use Mojo::File 'path';
+use Mojo::Util;
 use Mojo::Log;
 use ZnapZend::Config;
 use ZnapZend::ZFS;
@@ -574,7 +575,7 @@ my $daemonize = sub {
     my $pidFile = $self->pidfile || $self->defaultPidFile;
 
     if (-f $pidFile){
-        chomp(my $pid = slurp $pidFile);
+        chomp(my $pid = path($pidFile)->slurp);
         #pid is not empty and is numeric
         if ($pid && ($pid = int($pid)) && kill 0, $pid){
             die "I Quit! Another copy of znapzend ($pid) seems to be running. See $pidFile\n";


### PR DESCRIPTION
The slurp function has been removed in the latest Mojo release for that reason it's required to use the path function to slurp.