### PR TITLE
--sudo/pfexec znapzend options for consistency

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -12,13 +12,16 @@ my $opts = {};
 my %featureMap = map { $_ => 1 } qw(oracleMode recvu pfexec sudo compressed);
 
 sub main {
-    GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s),
+    GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s sudo pfexec),
         qw(daemonize pidfile=s logto=s loglevel=s runonce=s connectTimeout=s timeWarp=i autoCreation)) or exit 1;
 
     #split all features into individual options
     if ($opts->{features}){
         for my $feature (split /,/, $opts->{features}){
             $featureMap{$feature} or die "ERROR: feature '$feature' not supported\n";
+            if ($feature eq "pfexec" or $feature eq "sudo") {
+                warn "--features=" . $feature . " is deprecated. Use --" . $feature . " instead\n"
+            }
             $opts->{$feature} = 1;
         }
         delete $opts->{features};
@@ -53,7 +56,7 @@ znapzend - znapzend daemon
 
 =head1 SYNOPSIS
 
-B<znapzend> [I<options>...]
+B<znapzend> [I<options>...] [--sudo|pfexec]
 
  --man              show man-page and exit
  -h,--help          display this help and exit
@@ -66,6 +69,8 @@ B<znapzend> [I<options>...]
  --daemonize        fork into the background
  --runonce=x        run one round on source dataset x
  --features=x       comma separated list of features to be enabled
+ --pfexec           use 'pfexec' for zfs commands
+ --sudo             use 'sudo' for zfs commands
  --connectTimeout=x sets the ConnectTimeout for ssh commands
  --autoCreation     automatically create dataset on dest if it not exists
  --timeWarp=x       shift znapzends sens of NOW into the future by x seconds
@@ -156,24 +161,24 @@ can destroy. Logging an error about the problem
 use the -u option on the receive end, to keep the destination zfs
 filesystems unmounted.
 
-=item pfexec
-
-use 'pfexec' for zfs commands (e.g. when running znapzend as non-priviledged user)
-
-=item sudo
-
-use 'sudo' for zfs commands (e.g. when running znapzend as non-priviledged user)
-
 =item compressed
 
 use 'compressed' to add options -Lce to the zfs send command
 If a source and destination volume are both using compression, zfs send will, by
-default, decompress the data before sending. Zfs recv will then compress it again before 
+default, decompress the data before sending. Zfs recv will then compress it again before
 writing it to disk. Using -c will skip the unnecessary decompress-compress stages.
 This decreases CPU load on both source and destination as well as reduce network
 bandwidth. The -L option is for large block support and -e is for embedded data support.
 
 =back
+
+=item B<--pfexec>
+
+use 'pfexec' for zfs commands (e.g. when running znapzend as non-priviledged user)
+
+=item B<--sudo>
+
+use 'sudo' for zfs commands (e.g. when running znapzend as non-priviledged user)
 
 =item B<--connectTimeout>=I<timeout>
 

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -12,17 +12,20 @@ my $opts = {};
 my %featureMap = map { $_ => 1 } qw(oracleMode recvu pfexec sudo compressed);
 
 sub main {
-    GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s sudo pfexec),
-        qw(daemonize pidfile=s logto=s loglevel=s runonce=s connectTimeout=s timeWarp=i autoCreation)) or exit 1;
+    GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s),
+        qw(sudo pfexec rootExec=s daemonize pidfile=s logto=s loglevel=s),
+        qw(runonce=s connectTimeout=s timeWarp=i autoCreation)) or exit 1;
 
     #split all features into individual options
     if ($opts->{features}){
         for my $feature (split /,/, $opts->{features}){
             $featureMap{$feature} or die "ERROR: feature '$feature' not supported\n";
             if ($feature eq "pfexec" or $feature eq "sudo") {
-                warn "--features=" . $feature . " is deprecated. Use --" . $feature . " instead\n"
+                warn "--features=" . $feature . " is deprecated. Use --rootExec=" . $feature . " instead\n";
+                $opts->{rootExec} = $feature;
+            } else {
+                $opts->{$feature} = 1;
             }
-            $opts->{$feature} = 1;
         }
         delete $opts->{features};
     }
@@ -56,7 +59,7 @@ znapzend - znapzend daemon
 
 =head1 SYNOPSIS
 
-B<znapzend> [I<options>...] [--sudo|pfexec]
+B<znapzend> [I<options>...]
 
  --man              show man-page and exit
  -h,--help          display this help and exit
@@ -69,12 +72,11 @@ B<znapzend> [I<options>...] [--sudo|pfexec]
  --daemonize        fork into the background
  --runonce=x        run one round on source dataset x
  --features=x       comma separated list of features to be enabled
- --pfexec           use 'pfexec' for zfs commands
- --sudo             use 'sudo' for zfs commands
+ --rootExec=x       exec zfs with this command to obtain root privileges (sudo or pfexec)
  --connectTimeout=x sets the ConnectTimeout for ssh commands
  --autoCreation     automatically create dataset on dest if it not exists
  --timeWarp=x       shift znapzends sens of NOW into the future by x seconds
- 
+
 =head1 DESCRIPTION
 
 ZnapZend is a snapshot based zfs backup daemon creating snapshots on a
@@ -172,13 +174,17 @@ bandwidth. The -L option is for large block support and -e is for embedded data 
 
 =back
 
-=item B<--pfexec>
+=item B<--rootExec>={sudo|pfexec}
 
-use 'pfexec' for zfs commands (e.g. when running znapzend as non-priviledged user)
+Execute zfs with this command, 'sudo' or 'pfexec', to
+obtain root privileges. This is often necessary when running znapzend as a
+non-privileged user with a zfs install that doesn't support finer permission
+controls. This also applies to the zfs commands ran on remote servers over ssh.
 
-=item B<--sudo>
-
-use 'sudo' for zfs commands (e.g. when running znapzend as non-priviledged user)
+For sudo, the /etc/sudoers file will need to be modified to allow for
+passwordless access to zfs commands if znapzend is to be ran as a daemon or
+the system will be used as a remote. Many ZFS installations include an
+/etc/sudoers.d/zfs file as an example.
 
 =item B<--connectTimeout>=I<timeout>
 

--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -10,6 +10,9 @@ use Scalar::Util qw(blessed);
 use Mojo::Base -strict;
 use ZnapZend::Config;
 my $VERSION = '0.dev'; #VERSION
+
+my @ROOT_EXEC_OPTIONS = qw(pfexec sudo rootExec=s);
+
 sub dumpProperties {
     my $props = shift;
 
@@ -117,14 +120,23 @@ sub main {
     defined $mainOpt or pod2usage(1);
 
     Getopt::Long::Configure(qw(posix_default no_ignore_case pass_through));
-    GetOptions($opts, qw(pfexec sudo)) or exit 1;
+    GetOptions($opts, @ROOT_EXEC_OPTIONS) or exit 1;
     Getopt::Long::Configure(qw(posix_default no_ignore_case));
-    my $zConfig = ZnapZend::Config->new(pfexec => $opts->{pfexec}, sudo => $opts->{sudo});
+
+    if ($opts->{pfexec}) {
+        warn "--pfexec is deprecated. Use --rootExec=pfexec instead\n";
+        $opts->{rootExec} = 'pfexec';
+    } elsif ($opts->{sudo}) {
+        warn "--sudo is deprecated. Use --rootExec=sudo instead\n";
+        $opts->{rootExec} = 'sudo';
+    }
+
+    my $zConfig = ZnapZend::Config->new(rootExec => $opts->{rootExec});
 
     for ($mainOpt){
 
     /^create$/ && do {
-        GetOptions($opts, (qw(recursive|r donotask pfexec sudo mbuffer=s mbuffersize=s),
+        GetOptions($opts, (@ROOT_EXEC_OPTIONS, qw(recursive|r donotask mbuffer=s mbuffersize=s),
             qw(tsformat=s pre-snap-command=s post-snap-command=s send-delay=i))) or exit 1;
 
         $cfg{enabled}       = 'on';
@@ -164,7 +176,7 @@ sub main {
         last;
     };
     /^delete$/ && do {
-        GetOptions($opts, qw(pfexec sudo dst=s)) or exit 1;
+        GetOptions($opts, @ROOT_EXEC_OPTIONS, qw(dst=s)) or exit 1;
 
         $opts->{src} = pop @ARGV;
         defined $opts->{src} or pod2usage(1);
@@ -181,7 +193,9 @@ sub main {
     };
     /^edit$/ && do {
         #only dataset given so we use the editor based edit mode
-        if ($#ARGV == grep { /^--(?:sudo|pfexec)$/ } @ARGV){
+        my $ignoreOpts = $ROOT_EXEC_OPTIONS[0];
+        map { $ignoreOpts .= '|' . $_ } @ROOT_EXEC_OPTIONS[1 .. $#ROOT_EXEC_OPTIONS];
+        if ($#ARGV == grep { /^--(?:$ignoreOpts)$/ } @ARGV){
             $opts->{src} = pop @ARGV;
 
             my $backupSet = $zConfig->getBackupSet($opts->{src})->[0]
@@ -223,7 +237,7 @@ sub main {
             last;
         }
 
-        GetOptions($opts, (qw(donotask pfexec sudo recursive=s mbuffer=s mbuffersize=s),
+        GetOptions($opts, (@ROOT_EXEC_OPTIONS, qw(donotask recursive=s mbuffer=s mbuffersize=s),
             qw(tsformat=s pre-snap-command=s post-snap-command=s send-delay=i))) or exit 1;
 
         my $backupSet = parseArguments(\@ARGV);
@@ -309,7 +323,7 @@ sub main {
         my @props;
         my $fh;
 
-        GetOptions($opts, qw(pfexec sudo write|w), 'prop=s' => \@props) or exit 1;
+        GetOptions($opts, @ROOT_EXEC_OPTIONS, qw(write|w), 'prop=s' => \@props) or exit 1;
 
         if ($#ARGV){
             my $filename = pop @ARGV;
@@ -399,7 +413,7 @@ B<znapzendzetup> I<command> [I<options...>]
 
 where 'command' is one of the following:
 
-    create  [--pfexec|sudo] \
+    create  [--rootExec={pfexec|sudo}] \
             [--recursive] [--mbuffer=<path>[:<port>]] [--mbuffersize=<size>] \
             [--pre-snap-command=<command>] \
             [--post-snap-command=<command>] \
@@ -408,9 +422,9 @@ where 'command' is one of the following:
             SRC plan dataset \
             [ DST[:key] plan [[user@]host:]dataset [pre-send-command] [post-send-command] ]
 
-    delete  [--pfexec|sudo] [--dst=key] <src_dataset>
+    delete  [--rootExec={pfexec|sudo}] [--dst=key] <src_dataset>
 
-    edit    [--pfexec|sudo]
+    edit    [--rootExec={pfexec|sudo}]
             [--recursive=on|off] [--mbuffer=<path>[:<port>]|off] [--mbuffersize=<size>] \
             [--pre-snap-command=<command>|off] \
             [--post-snap-command=<command>|off] \
@@ -419,17 +433,17 @@ where 'command' is one of the following:
             SRC [plan] dataset \
             [ DST:key [plan] [dataset] [pre-send-command|off] [post-send-command|off] ]
 
-    edit    [--pfexec|sudo] <src_dataset>
+    edit    [--rootExec={pfexec|sudo}] <src_dataset>
 
-    enable  [--pfexec|sudo] <src_dataset>
+    enable  [--rootExec={pfexec|sudo}] <src_dataset>
 
-    disable [--pfexec|sudo] <src_dataset>
+    disable [--rootExec={pfexec|sudo}] <src_dataset>
 
-    list    [--pfexec|sudo] [src_dataset]
+    list    [--rootExec={pfexec|sudo}] [src_dataset]
 
-    export  [--pfexec|sudo] <src_dataset>
+    export  [--rootExec={pfexec|sudo}] <src_dataset>
 
-    import  [--pfexec|sudo] [--write] [--prop <property>=<value>, [--prop ...] ...]
+    import  [--rootExec={pfexec|sudo}] [--write] [--prop <property>=<value>, [--prop ...] ...]
             <src_dataset> [<prop_dump_file>]
 
     help

--- a/bin/znapzendztatz
+++ b/bin/znapzendztatz
@@ -45,10 +45,18 @@ sub collectData {
 sub main {
     my $opts = {};
 
-    GetOptions($opts, qw(H help|h recursive|r only-enabled pfexec sudo man timeWarp=i)) or exit 1;
+    GetOptions($opts, qw(H help|h recursive|r only-enabled pfexec sudo rootExec=s man timeWarp=i)) or exit 1;
 
-    $zZfs = ZnapZend::ZFS->new(pfexec => $opts->{pfexec}, sudo => $opts->{sudo});
-    $zConfig = ZnapZend::Config->new(pfexec => $opts->{pfexec}, sudo => $opts->{sudo}, timeWarp=> $opts->{timeWarp});
+    if ($opts->{pfexec}) {
+        warn "--pfexec is deprecated. Use --rootExec=pfexec instead\n";
+        $opts->{rootExec} = 'pfexec';
+    } elsif ($opts->{sudo}) {
+        warn "--sudo is deprecated. Use --rootExec=sudo instead\n";
+        $opts->{rootExec} = 'sudo';
+    }
+
+    $zZfs = ZnapZend::ZFS->new(rootExec => $opts->{rootExec});
+    $zConfig = ZnapZend::Config->new(rootExec => $opts->{rootExec}, timeWarp=> $opts->{timeWarp});
 
     $opts->{help} && do {
         pod2usage(-exitval => 'NOEXIT');
@@ -116,14 +124,13 @@ znapzendztatz - znapzend statistics utility
 
 =head1 SYNOPSIS
 
-B<znapzendztatz> [I<options>...] [--sudo|pfexec] [src_dataset]
+B<znapzendztatz> [I<options>...] [src_dataset]
 
  -H             do not print headers and separate fields by a single tab
                 instead of arbitrary white space
  -r,--recursive show statistics for dataset and sub datasets
  --only-enabled only show statistics for enabled datasets
- --pfexec       use 'pfexec' for zfs commands
- --sudo         use 'sudo' for zfs commands
+ --rootExec=x   exec zfs with this command to obtain root privileges (sudo or pfexec)
  --timeWarp=x   act as if you were shifted by x seconds into the future
  --man          show man-page and exit
  -h,--help      display this help and exit

--- a/bin/znapzendztatz
+++ b/bin/znapzendztatz
@@ -116,14 +116,14 @@ znapzendztatz - znapzend statistics utility
 
 =head1 SYNOPSIS
 
-B<znapzendztatz> [I<options>...] [src_dataset]
+B<znapzendztatz> [I<options>...] [--sudo|pfexec] [src_dataset]
 
  -H             do not print headers and separate fields by a single tab
                 instead of arbitrary white space
  -r,--recursive show statistics for dataset and sub datasets
  --only-enabled only show statistics for enabled datasets
- --pfexec       use 'pfexec' for commands
- --sudo         use 'sudo' for commands
+ --pfexec       use 'pfexec' for zfs commands
+ --sudo         use 'sudo' for zfs commands
  --timeWarp=x   act as if you were shifted by x seconds into the future
  --man          show man-page and exit
  -h,--help      display this help and exit

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -28,8 +28,7 @@ has nodestroy       => sub { 0 };
 has oracleMode      => sub { 0 };
 has recvu           => sub { 0 };
 has compressed      => sub { 0 };
-has pfexec          => sub { 0 };
-has sudo            => sub { 0 };
+has rootExec        => sub { q{} };
 has connectTimeout  => sub { 30 };
 has runonce         => sub { q{} };
 has daemonize       => sub { 0 };
@@ -45,7 +44,7 @@ has backupSets      => sub { [] };
 has zConfig => sub {
     my $self = shift;
     ZnapZend::Config->new(debug => $self->debug, noaction => $self->noaction,
-                          pfexec => $self->pfexec, sudo => $self->sudo, timeWarp => $self->timeWarp);
+                          rootExec => $self->rootExec, timeWarp => $self->timeWarp);
 };
 
 has zZfs => sub {
@@ -53,9 +52,8 @@ has zZfs => sub {
     ZnapZend::ZFS->new(debug => $self->debug, noaction => $self->noaction,
         nodestroy => $self->nodestroy, oracleMode => $self->oracleMode,
         recvu => $self->recvu, connectTimeout => $self->connectTimeout,
-        pfexec => $self->pfexec, sudo => $self->sudo,
+        rootExec => $self->rootExec,
         zLog => $self->zLog, compressed => $self->compressed);
-        
 };
 
 has zTime => sub { ZnapZend::Time->new(timeWarp=>shift->timeWarp) };

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -8,8 +8,7 @@ use Text::ParseWords qw(shellwords);
 ### attributes ###
 has debug    => sub { 0 };
 has noaction => sub { 0 };
-has pfexec   => sub { 0 };
-has sudo     => sub { 0 };
+has rootExec => sub { q{} };
 has timeWarp => sub { undef };
 
 #mandatory properties
@@ -25,7 +24,7 @@ has mandProperties => sub {
     }
 };
 
-has zfs  => sub { my $self = shift; ZnapZend::ZFS->new(pfexec => $self->pfexec, sudo => $self->sudo); };
+has zfs  => sub { my $self = shift; ZnapZend::ZFS->new(rootExec => $self->rootExec); };
 has time => sub { ZnapZend::Time->new(timeWarp=>shift->timeWarp); };
 
 has backupSets => sub { [] };

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -11,8 +11,7 @@ has nodestroy       => sub { 1 };
 has oracleMode      => sub { 0 };
 has recvu           => sub { 0 };
 has compressed      => sub { 0 };
-has pfexec          => sub { 0 };
-has sudo            => sub { 0 };
+has rootExec        => sub { q{} };
 has sendDelay       => sub { 3 };
 has connectTimeout  => sub { 30 };
 has propertyPrefix  => sub { q{org.znapzend} };
@@ -22,7 +21,7 @@ has mbufferParam    => sub { [qw(-q -s 128k -W 60 -m)] }; #don't remove the -m a
 has scrubInProgress => sub { qr/scrub in progress/ };
 
 has zLog            => sub { Mojo::Exception->throw('zLog must be specified at creation time!') };
-has priv            => sub { my $self = shift; [$self->pfexec ? qw(pfexec) : $self->sudo ? qw(sudo) : ()] };
+has priv            => sub { my $self = shift; [$self->rootExec ? split(/ /, $self->rootExec) : ()] };
 
 ### private functions ###
 my $splitHostDataSet     = sub { return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/); };


### PR DESCRIPTION
I noticed that there is a bit of an inconsistency between the options to znapzend and its utilities which made me briefly confused why znapzend doesn't accept sudo as an option. I then found https://github.com/oetiker/znapzend/issues/166 and realized others have been confused. I've moved these out from the "features" option to their own standalone options. It's still possible to use the old features flag, for backwards compatibility, but there will now be a warning issued to make the switch.

Closes #166 