### PR TITLE
Add support for %z specifier in tsformat option

### DIFF
--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -508,11 +508,11 @@ constructed.
 
 The syntax is L<strftime>-like. The string must consist of the mandatory
 
- %Y %m %d %H %M %S
+ %Y %m %d %H %M %S %z
 
 Optionally,
 
- - _ . :
+- _ . :
 
 characters as well as any alphanumeric character are allowed.
 

--- a/lib/ZnapZend/Time.pm
+++ b/lib/ZnapZend/Time.pm
@@ -226,7 +226,7 @@ sub checkTimeFormat {
     my $self = shift;
     my $timeFormat = shift;
 
-    $timeFormat =~ /^(?:%[YmdHMS]|[\w\-.:])+$/ or die "ERROR: timestamp format not valid. check your syntax\n";
+    $timeFormat =~ /^(?:%[YmdHMSz]|[\w\-.:])+$/ or die "ERROR: timestamp format not valid. check your syntax\n";
 
     #just a made-up timestamp to check if strftime and strptime work
     my $timeToCheck = 1014416542;
@@ -246,6 +246,7 @@ sub getSnapshotFilter {
 
     $timeFormat =~ s/%[mdHMS]/\\d{2}/g;
     $timeFormat =~ s/%Y/\\d{4}/g;
+    $timeFormat =~ s/%z/[-+]\\d{4}/g;
 
     # escape dot ('.') character
     $timeFormat =~ s/\./\\./g;


### PR DESCRIPTION
This implements the functionality requested in issue #297.

If "%z" isn't supported then checkTimeFormat should call die(), however I don't have access to such a platform to confirm this.