### PR TITLE
The cpanminus installation URL has changed.

### DIFF
--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -14,7 +14,7 @@ touch: CPAN/touch ../config.status ../PERL_MODULES
 
 CPAN/touch: ../PERL_MODULES
 	echo "POPULATING OUR LOCAL micro CPAN"
-	$(AM_V_GEN)$(URL_CAT) https://raw.githubusercontent.com/miyagawa/cpanminus/devel/cpanm | PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) - -q --notest --local-lib $(THIRDPARTY_DIR) --save-dists $(THIRDPARTY_DIR)/CPAN --force App::cpanminus
+	$(AM_V_GEN)$(URL_CAT) https://cpanmin.us | PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) - -q --notest --local-lib $(THIRDPARTY_DIR) --save-dists $(THIRDPARTY_DIR)/CPAN --force App::cpanminus
 	$(AM_V_GEN)PERL5LIB=$(THIRDPARTY_DIR)/Ore/lib/perl5 PERL_CPANM_HOME=$(THIRDPARTY_DIR)/Ore $(THIRDPARTY_DIR)/bin/cpanm -q --notest  --local-lib $(THIRDPARTY_DIR)/Ore File::Which OrePAN
 	$(AM_V_GEN)cat ../PERL_MODULES | PERL_CPANM_HOME=$(THIRDPARTY_DIR) xargs $(PERL) $(THIRDPARTY_DIR)/bin/cpanm -q --self-contained --notest --local-lib-contained $(THIRDPARTY_DIR) --save-dists $(THIRDPARTY_DIR)/CPAN
 	$(AM_V_GEN)PERL5LIB=$(THIRDPARTY_DIR)/Ore/lib/perl5 $(THIRDPARTY_DIR)/Ore/bin/orepan_index.pl --repository $(THIRDPARTY_DIR)/CPAN


### PR DESCRIPTION
The cpanminus maintainer has rearranged its github repository and the cpanminus installation URL in znapzend no longer works.  I changed it to the one recommended in [the current cpanminus README](https://github.com/miyagawa/cpanminus/tree/devel/App-cpanminus#user-content-installing-to-system-perl).

I did not regenerate the automake files for this request, since I'm using a different version of automake and using it would have introduced a lot of extraneous noise in the pull request.