### PR TITLE
Increase mbuffer watchdog timeout to 600 seconds

### DIFF
--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -17,7 +17,7 @@ has connectTimeout  => sub { 30 };
 has propertyPrefix  => sub { q{org.znapzend} };
 has sshCmdArray     => sub { [qw(ssh),
     qw(-o batchMode=yes -o), 'ConnectTimeout=' . shift->connectTimeout] };
-has mbufferParam    => sub { [qw(-q -s 128k -W 60 -m)] }; #don't remove the -m as the buffer size will be added
+has mbufferParam    => sub { [qw(-q -s 128k -W 600 -m)] }; #don't remove the -m as the buffer size will be added
 has scrubInProgress => sub { qr/scrub in progress/ };
 
 has zLog            => sub { Mojo::Exception->throw('zLog must be specified at creation time!') };


### PR DESCRIPTION
mbuffer activates its watchdog under certain circumstances which causes znapzend to abort and get stuck. See https://github.com/oetiker/znapzend/issues/341. This commit increases the timeout to 600 seconds to allow it enough time to complete.