### PR TITLE
znapzend.xml.in : do not go into maintenance if "zfs" coredumps

### DIFF
--- a/init/znapzend.xml.in
+++ b/init/znapzend.xml.in
@@ -43,6 +43,10 @@
                 exec=":kill -HUP"
                 timeout_seconds="180" />
 
+        <property_group name="startd" type="framework">
+             <propval name="ignore_error" type="astring" value="core,signal" />
+        </property_group>
+
         <stability 
                 value="Unstable" />
 


### PR DESCRIPTION
Assuming that the `znapzend` (script) calls a system program in a loop, and that program returns well or dies, the script should handle it somehow, e.g. go to the next iteration of the loop, or abort with error and cause service restart. Either way, for the hands-off end-user, the clock goes on ticking and snaps taken.