### PR TITLE
Allow use of /etc/default/znapzend for extra znapzend parameters in init files

### DIFF
--- a/init/README.md
+++ b/init/README.md
@@ -46,6 +46,10 @@ systemctl enable znapzend.service
 systemctl start znapzend.service
 ```
 
+If you want to set parameters for the znapzend daemon separately from the
+unit file, copy ```znapzend.default``` to ```/etc/default/znapzend``` and
+edit it.
+
 ## Upstart
 
 For upstart based systems, you can copy the generated ```znapzend.upstart```
@@ -54,3 +58,7 @@ file to ```/etc/init/znapzend.conf``` and start the daemon.
 ```sh
 service znapzend start
 ```
+
+If you want to set parameters for the znapzend daemon separately from the
+upstart file, copy ```znapzend.default``` to ```/etc/default/znapzend```
+and edit it.

--- a/init/znapzend.default
+++ b/init/znapzend.default
@@ -1,0 +1,2 @@
+# Command line options for znapzend
+ZNAPZENDOPTIONS=""

--- a/init/znapzend.service.in
+++ b/init/znapzend.service.in
@@ -5,7 +5,8 @@ After=zfs-import-cache.service
 After=zfs-import-scan.service
 
 [Service]
-ExecStart=@BINDIR@/znapzend
+EnvironmentFile=-/etc/default/znapzend
+ExecStart=@BINDIR@/znapzend $ZNAPZENDOPTIONS
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 # might be neccessary on low power systems

--- a/init/znapzend.upstart.in
+++ b/init/znapzend.upstart.in
@@ -1,4 +1,4 @@
-# znapzend: upstart file at /etc/init/znapzend.conf                                                                                                                                                                                   
+# znapzend: upstart file at /etc/init/znapzend.conf
 
 description "znapzend"
 
@@ -10,4 +10,10 @@ stop on runlevel [06]
 expect fork
 reload signal HUP
 
-exec @BINDIR@/znapzend --daemonize
+script
+  set -a
+  if [ -e /etc/default/znapzend ]; then
+    . /etc/default/znapzend
+  fi
+  @BINDIR@/znapzend --daemonize $ZNAPZENDOPTIONS
+end script


### PR DESCRIPTION
This brings the init files into alignment with standard packaging practices for various distributions.  It allows the init files to be included in a generic package while giving package users the latitude to pass their own parameters to the znapzend daemon.