### PR TITLE
System V init script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ thirdparty/*
 !thirdparty/Makefile.in
 *.tar.gz
 init/znapzend.service
+init/znapzend.sysv
 init/znapzend.upstart
 init/znapzend.xml

--- a/configure.ac
+++ b/configure.ac
@@ -191,6 +191,7 @@ AC_CONFIG_FILES([
     thirdparty/Makefile
     lib/Makefile
     init/znapzend.service
+    init/znapzend.sysv
     init/znapzend.upstart
     init/znapzend.xml
 ])

--- a/init/README.md
+++ b/init/README.md
@@ -62,3 +62,27 @@ service znapzend start
 If you want to set parameters for the znapzend daemon separately from the
 upstart file, copy ```znapzend.default``` to ```/etc/default/znapzend```
 and edit it.
+
+## System V
+
+For systems with SysV-based initscripts, you can copy the generated
+```znapzend.sysv``` file to ```/etc/init.d/znapzend``` and then enable and
+start the daemon.
+
+For Red Hat systems (RHEL, RHEL derivatives, and Fedora):
+
+```sh
+chkconfig znapzend on
+service znapzend start
+```
+
+For Debian systems:
+
+```sh
+update-rc.d znapzend defaults
+service znapzend start
+```
+
+If you want to set parameters for the znapzend daemon separately from the
+init script, copy ```znapzend.default``` to ```/etc/default/znapzend```
+and edit it.

--- a/init/znapzend.sysv.in
+++ b/init/znapzend.sysv.in
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+#       ZnapZend - ZFS Backup System
+#
+# chkconfig: 2345 20 80
+# config: /etc/default/znapzend
+# probe: true
+
+# Source function library.
+. /etc/init.d/functions
+
+if [ -e /etc/default/znapzend ]; then
+    . /etc/default/znapzend
+fi
+
+start() {
+    echo -n "Starting znapzend: "
+    daemon --check znapzend @BINDIR@/znapzend --daemonize $ZNAPZENDOPTIONS
+    RETVAL=$?
+    if [ $RETVAL -ne 0 ]; then
+        return $RETVAL
+    fi
+    touch /var/lock/subsys/znapzend
+    return 0
+}
+
+stop() {
+    echo -n "Shutting down znapzend: "
+    killproc znapzend
+    RETVAL=$?
+    rm -f /var/lock/subsys/znapzend
+    return $RETVAL
+}
+
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    status)
+        status znapzend
+        ;;
+    restart)
+        stop
+        start
+        ;;
+    reload)
+        killproc znapzend -HUP
+        ;;
+    condrestart)
+        [ -f /var/lock/subsys/znapzend ] && restart || :
+        ;;
+    *)
+        echo "Usage: znapzend {start|stop|status|reload|restart}"
+        exit 1
+        ;;
+esac
+exit $?


### PR DESCRIPTION
This adds a System V init script to the example scripts.  I added the script to `configure.ac`, but did not regenerate `configure` with autoconf.  (I have a different version of autotools installed than you do and me regenerating `configure` would introduce a lot of spurious changes to the commit.)