### PR TITLE
Minor fix to supress an error message when doing 'znapzendzetup list'…

### DIFF
--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -31,7 +31,12 @@ sub dumpProperties {
                 }
             }
             else{
-                print $opt . ' ' x (16 - length($opt)) . "= $backupSet->{$opt}\n";
+                if (length($opt) < 16) {
+                    print $opt . ' ' x (16 - length($opt)) . "= $backupSet->{$opt}\n";
+                }
+                else {
+                    print $opt . " = $backupSet->{$opt}\n";
+                }
             }
         }
         print "\n";


### PR DESCRIPTION
… if a property is greater than 16 characters long

Credit to Paul Pettigrew of Mach Technology.