### PR TITLE
Addressing issue #154

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -435,7 +435,7 @@ my $createSnapshot = sub {
 
         # restrict the list to the datasets that are descendant from the current
         my @dataSetList = grep /^$backupSet->{src}($|\/)/, @{$self->zZfs->listDataSets()};
-        if ( scalar @dataSetList > 0 ) {
+        if (@dataSetList) {
 
             # for each dataset: if the property "enabled" is set to "off", set the
             # newly created snapshot for removal
@@ -450,13 +450,14 @@ my $createSnapshot = sub {
                 # if the property does not exist, the command will just return. In this case,
                 # the value is implicit "on"
                 $prop = <$prop> || "on";
-                if ( substr($prop, 0, length('off')) eq 'off' ) {
+                chomp($prop);
+                if ( $prop eq 'off' ) {
                     push(@dataSetsExplicitelyDisabled, $dataSet . '@' . $snapshotSuffix);
                 }
             }
 
             # remove the snapshots previously marked
-           if ( scalar @dataSetsExplicitelyDisabled > 0 ){
+           if ( @dataSetsExplicitelyDisabled ){
                $self->zLog->info("Requesting removal of marked datasets: ". join( ", ", @dataSetsExplicitelyDisabled));
                $self->zZfs->destroySnapshots(@dataSetsExplicitelyDisabled);
            }

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -435,7 +435,7 @@ my $createSnapshot = sub {
 
         # restrict the list to the datasets that are descendant from the current
         my @dataSetList = grep /^$backupSet->{src}($|\/)/, @{$self->zZfs->listDataSets()};
-        if (@dataSetList) {
+        if ( @dataSetList ) {
 
             # for each dataset: if the property "enabled" is set to "off", set the
             # newly created snapshot for removal


### PR DESCRIPTION
As the sending of the ZFS streams is per stream, we can disable children ZFS from being snapshot/sent by setting the property "org.znapzend:enabled" to "off" on them. For the dataset being processed, in case the recursive flag is set, its children will be checked and their recently created snapshots removed.