### PR TITLE
Further fix for service integrations (fix evaluated vars other than PREFIX)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,43 @@
+commit 91e0a0dede87600aa554e38b6b5dff5fa3982f82
+Author: Jim Klimov <jim@jimklimov.com>
+Date:   Mon Sep 24 13:02:30 2018 +0200
+
+    Further fix for service integrations (fix evaluated vars other than PREFIX)
+
+commit 55461fcf93294fd62ae920ad5e5cd0bd2b224922
+Author: sylvain <sylvain@ilm-informatique.fr>
+Date:   Wed Sep 19 15:24:25 2018 +0200
+
+    added --setup option
+
+commit 4209a5e4ec381b86af1350222a7fe5efaa1e2012
+Author: Shaun Maher <shaun@ghanima.net>
+Date:   Tue Aug 14 18:38:48 2018 +1000
+
+    Minor fix to supress an error message when doing 'znapzendzetup list' if a property is greater than 16 characters long (#374)
+
+commit 24198cb439dc17aa54d4222093d4a31ea2adc621
+Author: flixman <felix@kngnt.org>
+Date:   Mon Jul 16 14:08:06 2018 +0000
+
+    Adding note about ZFS permissions for unprivileged users (#373)
+    
+    * Update znapzendzetup
+    
+    * Update README.md
+
+commit c604a86857430258c2b8479c356437c0f61a4dc6
+Author: Tobias Oetiker <tobi@oetiker.ch>
+Date:   Wed Jun 27 09:09:06 2018 +0200
+
+    update list of files included in dist
+
+commit 5ec68eede2c9e697cdfaafc9528b9b016fa4b212
+Author: Tobias Oetiker <tobi@oetiker.ch>
+Date:   Tue Jun 19 17:27:34 2018 +0200
+
+    release 0.19.0
+
 commit 972c74daed1d09b83f88b65483f86ad46a4f4592
 Author: Manuel Oetiker <manuel@oetiker.ch>
 Date:   Fri Jun 15 09:27:00 2018 +0200

--- a/Makefile.in
+++ b/Makefile.in
@@ -349,7 +349,8 @@ POD = doc/znapzend.pod doc/znapzendzetup.pod doc/znapzendztatz.pod
 THIRDPARTY_DIR := $(shell pwd)/thirdparty
 GENERATED_EXTRADIST = $(MAN)
 EXTRA_DIST = VERSION COPYRIGHT README.md LICENSE CHANGES AUTHORS PERL_MODULES $(BIN) $(PM) \
-	$(GENERATED_EXTRADIST) init/znapzend.xml.in init/znapzend.service init/README.md \
+	$(GENERATED_EXTRADIST) init/README.md init/org.znapzend.plist.in  init/znapzend.default  \
+	init/znapzend.service.in  init/znapzend.sysv.in  init/znapzend.upstart.in  init/znapzend.xml.in \
 	t/autoscrub.t t/ssh t/znapzend.t t/znapzendztatz.t t/mbuffer \
 	t/zfs t/znapzendzetup.t t/zpool
 

--- a/configure
+++ b/configure
@@ -2566,6 +2566,12 @@ AM_BACKSLASH='\'
 
 
 
+if test x"${prefix}" = x"NONE"; then :
+  prefix="${ac_default_prefix}"
+fi
+if test x"${exec_prefix}" = x"NONE"; then :
+  exec_prefix='${prefix}'
+fi
 
 
 # Extract the first word of "perl", so it can be a program name with args.
@@ -3002,6 +3008,7 @@ fi
 
 
 
+# TODO: Is this block needed? No code seems to refer this varname...
 actual_prefix=$prefix
 if test x$actual_prefix = xNONE; then
     actual_prefix=$ac_default_prefix

--- a/configure.ac
+++ b/configure.ac
@@ -15,6 +15,9 @@ AM_MAINTAINER_MODE
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_PREFIX_DEFAULT(/opt/$PACKAGE_NAME-$PACKAGE_VERSION)
+dnl Fix this early so we can expand with eval later; note literal single quotes in exec_prefix
+AS_IF([test x"${prefix}" = x"NONE"], [prefix="${ac_default_prefix}"])
+AS_IF([test x"${exec_prefix}" = x"NONE"], [exec_prefix='${prefix}'])
 
 AC_ARG_VAR(PERL,   [Path to local perl binary])
 AC_PATH_PROG(PERL, perl, no)
@@ -117,6 +120,7 @@ AC_ARG_ENABLE(pkgonly,
                         [Skip all checking]))
 AC_SUBST(enable_pkgonly)
 
+# TODO: Is this block needed? No code seems to refer this varname...
 actual_prefix=$prefix
 if test x$actual_prefix = xNONE; then
     actual_prefix=$ac_default_prefix


### PR DESCRIPTION
Should fix inadequacies reported in #348 

Also updates `Makefile.in` for users who do not `./bootstrap.sh` by themselves.