### PR TITLE
Notify when a property is not available, and skip to the next dataset.

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -47,7 +47,8 @@ has backupSets              => sub { [] };
 has zConfig => sub {
     my $self = shift;
     ZnapZend::Config->new(debug => $self->debug, noaction => $self->noaction,
-                          rootExec => $self->rootExec, timeWarp => $self->timeWarp);
+                          rootExec => $self->rootExec, timeWarp => $self->timeWarp, 
+                          zLog => $self->zLog);
 };
 
 has zZfs => sub {

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -10,6 +10,7 @@ has debug    => sub { 0 };
 has noaction => sub { 0 };
 has rootExec => sub { q{} };
 has timeWarp => sub { undef };
+has zLog => sub { Mojo::Exception->throw('zLog must be specified at creation time!') };
 
 #mandatory properties
 has mandProperties => sub {
@@ -67,8 +68,10 @@ my $checkBackupSets = sub {
 
     for my $backupSet (@{$self->backupSets}){
         for my $prop (keys %{$self->mandProperties}){
-            exists $backupSet->{$prop}
-                or die "ERROR: property $prop not set on backup for " . $backupSet->{src} . "\n";
+            exists $backupSet->{$prop} || do {
+                $self->zLog->info("WARNING: property $prop not set on backup for " . $backupSet->{src} . ". Skipping to next dataset");
+                last;
+            };
                 
             for ($self->mandProperties->{$prop}){
                 #check mandatory properties


### PR DESCRIPTION
When a property on a dataset is not available, znapzend dies with an error message. This PR changes that by a warning and the skipping of that dataset. By doing this, we can set org.znapzend properties on descendant datasets (specifically thinking on the org.znapzend:enable, to skip those datasets that have it set to "off" when coming from a recursive parent).