### PR TITLE
More flexible handling of offline destinations

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -15,7 +15,7 @@ sub main {
     GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s),
         qw(sudo pfexec rootExec=s daemonize pidfile=s logto=s loglevel=s),
         qw(runonce:s connectTimeout=s timeWarp=i autoCreation version),
-        qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail)) or exit 1;
+        qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail cleanOffline)) or exit 1;
 
     $opts->{version} && do {
         print "znapzend version $VERSION\n";
@@ -90,6 +90,7 @@ B<znapzend> [I<options>...]
  --timeWarp=x           shift znapzends sens of NOW into the future by x seconds
  --skipOnPreSnapCmdFail skip snapshots if the pre-snap-command fails
  --skipOnPreSendCmdFail skip replication if the pre-send-command fails
+ --cleanOffline         clean up source snapshots even if a destination was offline
 
 =head1 DESCRIPTION
 
@@ -226,6 +227,13 @@ defined and the command returns a non-zero exit code or is killed by a signal.
 Prevent snapshots of a dataset from being replicated to a destination when it has
 a pre-snap-command defined and the command returns a non-zero exit code or is killed
 by a signal.
+
+=item B<--cleanOffline>
+
+Clean snapshots of a source dataset even if one or more destination datasets failed during replication.
+The most recent common snapshot for each destination will not be deleted, but this is a
+potentially dangerous option. If the preserved snapshot somehow gets deleted from the
+destination, it may require a full re-replication the next time it is online.
 
 =back
 

--- a/doc/znapzend.pod
+++ b/doc/znapzend.pod
@@ -24,6 +24,7 @@ B<znapzend> [I<options>...]
  --timeWarp=x           shift znapzends sens of NOW into the future by x seconds
  --skipOnPreSnapCmdFail skip snapshots if the pre-snap-command fails
  --skipOnPreSendCmdFail skip replication if the pre-send-command fails
+ --cleanOffline         clean up source snapshots even if a destination was offline
 
 =head1 DESCRIPTION
 
@@ -160,6 +161,13 @@ defined and the command returns a non-zero exit code or is killed by a signal.
 Prevent snapshots of a dataset from being replicated to a destination when it has
 a pre-snap-command defined and the command returns a non-zero exit code or is killed
 by a signal.
+
+=item B<--cleanOffline>
+
+Clean snapshots of a source dataset even if one or more destination datasets failed during replication.
+The most recent common snapshot for each destination will not be deleted, but this is a
+potentially dangerous option. If the preserved snapshot somehow gets deleted from the
+destination, it may require a full re-replication the next time it is online.
 
 =back
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -293,7 +293,7 @@ my $sendRecvCleanup = sub {
                 local $@;
                 eval {
                     local $SIG{__DIE__};
-                    $self->zZfs->sendRecvSnapshots($srcDataSet, $dstDataSet,
+                    $self->zZfs->sendRecvSnapshots($srcDataSet, $dstDataSet, $dst,
                         $backupSet->{mbuffer}, $backupSet->{mbuffer_size}, $backupSet->{snapFilter});
                 };
                 if ($@){

--- a/t/zfs
+++ b/t/zfs
@@ -65,6 +65,19 @@ for ($command){
             print "10G\n";
             exit;
         }
+        if ($ARGV[-1] && $ARGV[-1] =~ /@/){
+            my ($dataSet) = $ARGV[-1] =~ /([^@]*)@/;
+            exit if !(exists $dataSets{$dataSet} && $dataSets{$dataSet} eq 'src');
+            print<<"ZFS_GET_END";
+org.znapzend:dst_0            backup/destination
+org.znapzend:dst_0_synced     1
+org.znapzend:dst_a            root\@remote:remote/destination
+org.znapzend:dst_a_synced     1
+org.znapzend:dst_fail         backup/destfail
+org.znapzend:dst_fail_synced  1
+ZFS_GET_END
+            exit;
+        }
         exit if !(exists $dataSets{$ARGV[-1]} && $dataSets{$ARGV[-1]} eq 'src');
         print <<"ZFS_GET_END";
 org.znapzend:dst_0_plan     1hours=>10minutes,30minutes=>5minutes,10minutes=>60seconds

--- a/t/znapzend.t
+++ b/t/znapzend.t
@@ -73,7 +73,7 @@ throws_ok { runCommand(qw(--runonce=nosets) ) } qr/No backup set defined or enab
 is (runCommand('--help'), 1, 'znapzend help');
 
 is (runCommand(qw(--daemonize --debug),'--features=oracleMode,recvu',
-    qw( --pidfile=znapzend.pid)), 1, 'znapzend --daemonize');
+    qw( --pidfile=znapzend.pid --cleanOffline)), 1, 'znapzend --daemonize');
 
 done_testing;
 


### PR DESCRIPTION
My use case is to have two backup destinations which I alternate between being local and being offline and offsite (i.e. I pull the "off" backup disks and store them offsite). With this setup, both destinations are almost never online at the same time (when I'm switching I pull the live one, take it to the offsite location, swap it for the alternate and bring that back to install). Because of that, the original behaviour of never cleaning up source snapshots if any destination failed would cause the source snapshots to never get cleaned up, which is not ideal.

This changes that by marking the last sent snapshot on every successful send, ensuring that the most recent sent snapshot for each destination is never deleted, and finally optionally cleaning up the source snapshots. So unless the destination changes unexpectedly, there should still be a common snapshot to synchronize incrementally from.

The cleaning of source snapshots is turned on by an option because the original behaviour is probably safer in general, and so should be the default for use cases where offline destinations are not usual conditions. However, marking the sent snapshots and ensuring the most recent one is not deleted seems like potentially useful behaviour in general, so they are always on. I also fixed an inconsistency with how deleting destination snapshots work in the presence of failures (the behaviour differed depending on the order the destinations were synced in).

BTW, this is the first time I've done anything in Perl, so I'm sorry in advance if I've made any egregious mistakes due to that.