### PR TITLE
Enabling a pre-check for datasets with only the 'enabled' property set, which is a legitimate situation.

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -47,7 +47,8 @@ has backupSets              => sub { [] };
 has zConfig => sub {
     my $self = shift;
     ZnapZend::Config->new(debug => $self->debug, noaction => $self->noaction,
-                          rootExec => $self->rootExec, timeWarp => $self->timeWarp);
+                          rootExec => $self->rootExec, timeWarp => $self->timeWarp, 
+                          zLog => $self->zLog);
 };
 
 has zZfs => sub {

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -10,6 +10,7 @@ has debug    => sub { 0 };
 has noaction => sub { 0 };
 has rootExec => sub { q{} };
 has timeWarp => sub { undef };
+has zLog => sub { Mojo::Exception->throw('zLog must be specified at creation time!') };
 
 #mandatory properties
 has mandProperties => sub {
@@ -67,8 +68,10 @@ my $checkBackupSets = sub {
 
     for my $backupSet (@{$self->backupSets}){
         for my $prop (keys %{$self->mandProperties}){
-            exists $backupSet->{$prop}
-                or die "ERROR: property $prop not set on backup for " . $backupSet->{src} . "\n";
+            exists $backupSet->{$prop} || do {
+                $self->zLog->info("WARNING: property $prop not set on backup for " . $backupSet->{src} . ". Skipping to next dataset");
+                last;
+            };
                 
             for ($self->mandProperties->{$prop}){
                 #check mandatory properties

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -67,6 +67,16 @@ my $checkBackupSets = sub {
     my $self = shift;
 
     for my $backupSet (@{$self->backupSets}){
+
+        # in case there is only one property on this dataset, which is the "enabled" and is set to "off"
+        # consider it a normal situation and do not even notify it. This situation will appear
+        # when there are descendants of recursive ZFS dataset that should be skipped.
+        # Note: backupSets will have at least the key "Src". Therefore, we need to skip the
+        # dataset if there are two properties and one of them is "enabled".
+        if (keys(%{$backupSet}) eq 2 && exists($backupSet->{"enabled"})){
+           next;
+        }
+
         for my $prop (keys %{$self->mandProperties}){
             exists $backupSet->{$prop} || do {
                 $self->zLog->info("WARNING: property $prop not set on backup for " . $backupSet->{src} . ". Skipping to next dataset");


### PR DESCRIPTION
When a dataset only contains two properties, being src and enabled, we are considering this to be a legitimate situation: the dataset might well be a descendant from another, set that to recursive, for which we want to skip the snapshot generation and sending.

In this case, if this situation is detected, we just continue with the next dataset (we do not even log this situation, as it is not logged neither when datasets are correct).