### PR TITLE
Don't use deprecated Mojo::Util::slurp

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -2,7 +2,6 @@ package ZnapZend;
 
 use Mojo::Base -base;
 use Mojo::IOLoop::ForkCall;
-use Mojo::Util qw(slurp);
 use Mojo::Log;
 use ZnapZend::Config;
 use ZnapZend::ZFS;
@@ -638,7 +637,9 @@ my $daemonize = sub {
     my $pidFile = $self->pidfile || $self->defaultPidFile;
 
     if (-f $pidFile){
-        chomp(my $pid = slurp $pidFile);
+        open my $fh, $pidFile or die "ERROR: pid file '$pidFile' exists but is not readable\n";
+        chomp(my $pid = <$fh>);
+        close $fh;
         #pid is not empty and is numeric
         if ($pid && ($pid = int($pid)) && kill 0, $pid){
             die "I Quit! Another copy of znapzend ($pid) seems to be running. See $pidFile\n";


### PR DESCRIPTION
As of Mojo 7.15, Mojo::Util::slurp is deprecated in favour of Mojo::File::slurp. As of 7.31, it is removed entirely. We only use it to read the PID file.