### PR TITLE
Fix For ProxMox 5.x

### DIFF
--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -11,7 +11,6 @@ has nodestroy       => sub { 1 };
 has oracleMode      => sub { 0 };
 has recvu           => sub { 0 };
 has compressed      => sub { 0 };
-has netcat          => sub { 1 };
 has rootExec        => sub { q{} };
 has sendDelay       => sub { 3 };
 has connectTimeout  => sub { 30 };

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -11,6 +11,7 @@ has nodestroy       => sub { 1 };
 has oracleMode      => sub { 0 };
 has recvu           => sub { 0 };
 has compressed      => sub { 0 };
+has netcat          => sub { 1 };
 has rootExec        => sub { q{} };
 has sendDelay       => sub { 3 };
 has connectTimeout  => sub { 30 };
@@ -410,6 +411,8 @@ sub sendRecvSnapshots {
         );
         #start forkcall event loop
         $fc->ioloop->start if !$fc->ioloop->is_running;
+        #wake up event loop
+        $fc->ioloop->one_tick();
     }
     else {
         my @mbCmd = $mbuffer ne 'off' ? ([$mbuffer, @{$self->mbufferParam}, $mbufferSize]) : () ;


### PR DESCRIPTION
I'm not sure if this is the current way to fix this or not. I'm not a Perl programmer at all and this is mostly Greek to me. 

That said I've been using ZnapZend for ages without issue under OmniOS and when I moved to proxmox 5.x(aka Debian Stretch with a custom kernel) ZnapZend stopped working. It may have worked on 4.x but I made the switch just has 5.x was released so I never ran production on 4.x. 

Anyways, I traced the issue down to section of code under '#spawn event' never coming to life. The remote recv process fires up without issue but the local send command never happens and any debug statements inside $fc->on( spawn => sub { never get called.

My fix is to add the the one_tick() call. I've been running this for a year now with great results. I was using the .19 release branch and recently moved to head, which out issue. I tested head first without my fix and got the same results as before.

Thank you for making this great little script.