### PR TITLE
Fixes oetiker/znapzend#402 "Code review - my $splitHostDataSet differs between Config.pm and ZFS.pm"

### DIFF
--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -31,7 +31,7 @@ has time => sub { ZnapZend::Time->new(timeWarp=>shift->timeWarp); };
 has backupSets => sub { [] };
 
 ### private functions ###
-my $splitHostDataSet = sub { return ($_[0] =~ /^(?:([^:]+):)?([^:]+)$/); };
+my $splitHostDataSet = sub { return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/); };
 
 ### private methods ###
 my $checkBackupPlan = sub {
@@ -175,6 +175,7 @@ my $getBackupSet = sub {
     return $self->backupSets;
 };
 
+### public methods ###
 sub getBackupSet {
     my $self = shift;
 


### PR DESCRIPTION
`Config.pm` now uses the same definition of `$splitHostDataSet` as `ZFS.pm`.