### PR TITLE
zetup: Don't expand variables in printf format

### DIFF
--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -31,7 +31,7 @@ sub dumpProperties {
                 }
             }
             else{
-                printf("%16s = $backupSet->{$opt}\n",$opt);
+                printf("%16s = %s\n",$opt,$backupSet->{$opt});
             }
         }
         print "\n";


### PR DESCRIPTION
Expanding the timestamp option inside the printf format string results
in printf warnings because the % characters get interpreted as format
specifiers.

Fixes: #409