### PR TITLE
Problem: no easy way to runonce a pool or dataset tree

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -15,7 +15,7 @@ sub main {
     GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s),
         qw(sudo pfexec rootExec=s daemonize pidfile=s logto=s loglevel=s),
         qw(runonce:s connectTimeout=s timeWarp=i autoCreation version),
-        qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail)) or exit 1;
+        qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail recursive|r)) or exit 1;
 
     $opts->{version} && do {
         print "znapzend version $VERSION\n";
@@ -39,6 +39,12 @@ sub main {
     if (defined($opts->{runonce})) {
         $opts->{dataset} = $opts->{runonce};
         $opts->{runonce} = 1;
+    }
+
+    if (defined($opts->{recursive})) {
+        $opts->{recursive} = 1;
+    } else {
+        $opts->{recursive} = 0;
     }
 
     $opts->{help} && do {
@@ -83,6 +89,7 @@ B<znapzend> [I<options>...]
  --pidfile=x            write a pid file when running in daemon mode
  --daemonize            fork into the background
  --runonce=[x]          run one round on the optionally provided dataset
+ -r,--recursive         recurse from the given "run-once" dataset
  --features=x           comma separated list of features to be enabled
  --rootExec=x           exec zfs with this command to obtain root privileges (sudo or pfexec)
  --connectTimeout=x     sets the ConnectTimeout for ssh commands
@@ -142,7 +149,15 @@ Fork into the background.
 
 run one round on source I<dataset> or on all datasets if empty.
 This is very useful for testing. Use it in connection with B<--noaction> and
-B<--debug> while testing your new configuration
+B<--debug> while testing your new configuration, or with B<--recursive> for
+quick back up of whatever has backup plans in a single pool or dataset tree.
+
+=item B<-r>, B<--recursive>
+
+when backing up a particular dataset with B<--runonce>=[I<dataset>], do not
+just look at this dataset's backup plan, but iterate into its children that
+might have any. Useful for quick backups of a pool whose root dataset has no
+I<znapzendzetup> configurations defined, but some trees under it do.
 
 =item B<--features>=I<feature1>,I<feature2>,...
 

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -44,7 +44,12 @@ sub main {
     if (defined($opts->{recursive})) {
         $opts->{recursive} = 1;
     } else {
-        $opts->{recursive} = 0;
+        if (1 == $opts->{runonce}) {
+            $opts->{recursive} = 0;
+        } else {
+            # Effectively, recurse our whole ZFS namespace from its null root
+            $opts->{recursive} = 1;
+        }
     }
 
     $opts->{help} && do {

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -132,7 +132,7 @@ my $refreshBackupPlans = sub {
     $self->zLog->info('refreshing backup plans for dataset "' . $dataSet . '" ...');
     $self->backupSets($self->zConfig->getBackupSetEnabled($recurse, $dataSet));
 
-    @{$self->backupSets}
+    ($self->backupSets && @{$self->backupSets})
         or die "No backup set defined or enabled, yet. run 'znapzendzetup' to setup znapzend\n";
 
     for my $backupSet (@{$self->backupSets}){

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -220,10 +220,18 @@ my $sendRecvCleanup = sub {
     #no HUP handler in child
     $SIG{HUP} = 'IGNORE';
 
-    if ($backupSet->{zend_delay} and $backupSet->{zend_delay} > 0){
-        $self->zLog->info("waiting $backupSet->{zend_delay} seconds before sending snaps on backupSet $backupSet->{src}...");
-        sleep $backupSet->{zend_delay};
-        $self->zLog->info("resume sending action on backupSet $backupSet->{src}");
+    if ($backupSet->{zend_delay}) {
+        chomp $backupSet->{zend_delay};
+        if (!($backupSet->{zend_delay} =~ /^\d+$/)) {
+            warn "Option 'zend-delay' has an invalid value, ignored";
+            undef $backupSet->{zend_delay};
+        } else {
+            if($backupSet->{zend_delay} > 0) {
+                $self->zLog->info("waiting $backupSet->{zend_delay} seconds before sending snaps on backupSet $backupSet->{src}...");
+                sleep $backupSet->{zend_delay};
+                $self->zLog->info("resume sending action on backupSet $backupSet->{src}");
+            }
+        }
     }
 
     my @snapshots;

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -31,6 +31,7 @@ has lowmemRecurse           => sub { 0 };
 has rootExec                => sub { q{} };
 has connectTimeout          => sub { 30 };
 has runonce                 => sub { 0 };
+has recursive               => sub { 0 };
 has dataset                 => sub { q{} };
 has daemonize               => sub { 0 };
 has loglevel                => sub { q{debug} };
@@ -125,10 +126,11 @@ my $killThemAll  = sub {
 
 my $refreshBackupPlans = sub {
     my $self = shift;
+    my $recurse = shift;
     my $dataSet = shift;
 
     $self->zLog->info('refreshing backup plans for dataset "' . $dataSet . '" ...');
-    $self->backupSets($self->zConfig->getBackupSetEnabled($dataSet));
+    $self->backupSets($self->zConfig->getBackupSetEnabled($recurse, $dataSet));
 
     @{$self->backupSets}
         or die "No backup set defined or enabled, yet. run 'znapzendzetup' to setup znapzend\n";
@@ -786,11 +788,11 @@ sub start {
         for my $backupSet (@{$self->backupSets}){
             Mojo::IOLoop->remove($backupSet->{timer_id}) if $backupSet->{timer_id};
         }
-        $self->$refreshBackupPlans($self->dataset);
+        $self->$refreshBackupPlans($self->recursive, $self->dataset);
         $self->$createWorkers;
     };
 
-    $self->$refreshBackupPlans($self->dataset);
+    $self->$refreshBackupPlans($self->recursive, $self->dataset);
 
     $self->$createWorkers;
 

--- a/man/znapzend.1
+++ b/man/znapzend.1
@@ -156,6 +156,7 @@ znapzend \- znapzend daemon
 \& \-\-pidfile=x            write a pid file when running in daemon mode
 \& \-\-daemonize            fork into the background
 \& \-\-runonce=[x]          run one round on the optionally provided dataset
+\& \-r,\-\-recursive         recurse from the given "run\-once" dataset
 \& \-\-features=x           comma separated list of features to be enabled
 \& \-\-rootExec=x           exec zfs with this command to obtain root privileges (sudo or pfexec)
 \& \-\-connectTimeout=x     sets the ConnectTimeout for ssh commands
@@ -207,7 +208,14 @@ Fork into the background.
 .IX Item "--runonce=[dataset]"
 run one round on source \fIdataset\fR or on all datasets if empty.
 This is very useful for testing. Use it in connection with \fB\-\-noaction\fR and
-\&\fB\-\-debug\fR while testing your new configuration
+\&\fB\-\-debug\fR while testing your new configuration, or with \fB\-\-recursive\fR for
+quick back up of whatever has backup plans in a single pool or dataset tree.
+.IP "\fB\-r\fR, \fB\-\-recursive\fR" 4
+.IX Item "-r, --recursive"
+when backing up a particular dataset with \fB\-\-runonce\fR=[\fIdataset\fR], do not
+just look at this dataset's backup plan, but iterate into its children that
+might have any. Useful for quick backups of a pool whose root dataset has no
+\&\fIznapzendzetup\fR configurations defined, but some trees under it do.
 .IP "\fB\-\-features\fR=\fIfeature1\fR,\fIfeature2\fR,..." 4
 .IX Item "--features=feature1,feature2,..."
 enables enhanced zfs features not supported by all zfs implementations.

--- a/t/znapzend.t
+++ b/t/znapzend.t
@@ -73,6 +73,13 @@ $ENV{'ZNAPZENDTEST_ZFS_GET_ZEND_DELAY'} = '1';
 is (runCommand(qw(--runonce=tank/source)), 1, 'znapzend --runonce=tank/source with zend-delay==1');
 undef $ENV{'ZNAPZENDTEST_ZFS_GET_ZEND_DELAY'};
 
+# Try an invalid string, should ignore and proceed without a delay
+$ENV{'ZNAPZENDTEST_ZFS_GET_ZEND_DELAY'} = ' qwe ';
+# TODO : Find a way to check stderr for qr/Option 'zend-delay' has an invalid value/
+is (runCommand(qw(--runonce=tank/source)),
+    1, 'znapzend --runonce=tank/source with zend-delay==" qwe " complains but survives');
+undef $ENV{'ZNAPZENDTEST_ZFS_GET_ZEND_DELAY'};
+
 # seems to allow tests to continue so why not?
 is (runCommand('--help'), 1, 'znapzend help');
 

--- a/t/znapzend.t
+++ b/t/znapzend.t
@@ -62,6 +62,7 @@ use_ok 'ZnapZend';
 @ARGV = qw(--help);
 do 'znapzend' or die "ERROR: loading program znapzend\n";
 
+# seems to allow tests to continue so why not?
 is (runCommand('--help'), 1, 'znapzend help');
 
 is (runCommand(), 1, 'znapzend');
@@ -79,9 +80,6 @@ $ENV{'ZNAPZENDTEST_ZFS_GET_ZEND_DELAY'} = ' qwe ';
 is (runCommand(qw(--runonce=tank/source)),
     1, 'znapzend --runonce=tank/source with zend-delay==" qwe " complains but survives');
 undef $ENV{'ZNAPZENDTEST_ZFS_GET_ZEND_DELAY'};
-
-# seems to allow tests to continue so why not?
-is (runCommand('--help'), 1, 'znapzend help');
 
 # Coverage for various failure codepaths
 $ENV{'ZNAPZENDTEST_ZFS_GET_DST0PRECMD_FAIL'} = '1';

--- a/t/znapzend.t
+++ b/t/znapzend.t
@@ -81,6 +81,8 @@ is (runCommand(qw(--runonce=tank/source)),
     1, 'znapzend --runonce=tank/source with zend-delay==" qwe " complains but survives');
 undef $ENV{'ZNAPZENDTEST_ZFS_GET_ZEND_DELAY'};
 
+is (runCommand(qw(--runonce=tank -r)), 1, 'znapzend runonce recursing from a dataset without plan (pool root) succeeds');
+
 # Coverage for various failure codepaths
 $ENV{'ZNAPZENDTEST_ZFS_GET_DST0PRECMD_FAIL'} = '1';
 is (runCommand(qw(--runonce=tank/source)), 1, 'znapzend sendRecvCleanup with a failed DST PRE command');


### PR DESCRIPTION
Solution: add recurse ability to `znapzend --runonce=x -r` with same
logic as in `znapzendzetup list -r x`

Signed-off-by: Jim Klimov <jimklimov@gmail.com>

PS: While CI did not complain, seems this also fixes an omission from my recent PR #439 about `getBackupSetEnabled()` usage without a recursion arg that it still should send into `getBackupSet()`.