### PR TITLE
Problem: selftests spew "Variable will not stay shared"

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -99,7 +99,8 @@ has zLog => sub {
     return $log;
 };
 
-my $killThemAll  = sub {
+### private methods ###
+our $killThemAll  = sub {
     my $self = shift;
 
     $self->zLog->info("terminating znapzend (PID=$$) ...");
@@ -124,7 +125,7 @@ my $killThemAll  = sub {
     exit 0;
 };
 
-my $refreshBackupPlans = sub {
+our $refreshBackupPlans = sub {
     my $self = shift;
     my $recurse = shift;
     my $dataSet = shift;
@@ -213,7 +214,7 @@ my $refreshBackupPlans = sub {
     }
 };
 
-my $sendRecvCleanup = sub {
+our $sendRecvCleanup = sub {
     my $self = shift;
     my $backupSet = shift;
     my $timeStamp = shift;
@@ -479,7 +480,7 @@ my $sendRecvCleanup = sub {
     return 1;
 };
 
-my $createSnapshot = sub {
+our $createSnapshot = sub {
     my $self = shift;
     my $backupSet = shift;
     my $timeStamp = shift;
@@ -573,7 +574,7 @@ my $createSnapshot = sub {
     return 1;
 };
 
-my $sendWorker = sub {
+our $sendWorker = sub {
     my $self = shift;
     my $backupSet = shift;
     my $timeStamp = shift;
@@ -624,7 +625,7 @@ my $sendWorker = sub {
     );
 };
 
-my $snapWorker = sub {
+our $snapWorker = sub {
     my $self = shift;
     my $backupSet = shift;
     my $timeStamp = shift;
@@ -684,7 +685,7 @@ my $snapWorker = sub {
     );
 };
 
-my $createWorkers = sub {
+our $createWorkers = sub {
     my $self = shift;
 
     #create a timer for each backup set
@@ -734,7 +735,7 @@ my $createWorkers = sub {
 
 };
 
-my $daemonize = sub {
+our $daemonize = sub {
     my $self = shift;
     my $pidFile = $self->pidfile || $self->defaultPidFile;
 
@@ -783,6 +784,7 @@ my $daemonize = sub {
     }
 };
 
+### public methods ###
 sub start {
     my $self = shift;
 

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -13,7 +13,7 @@ has rootExec => sub { q{} };
 has timeWarp => sub { undef };
 has zLog => sub { Mojo::Exception->throw('zLog must be specified at creation time!') };
 
-#mandatory properties
+### mandatory properties ###
 has mandProperties => sub {
     {
         enabled       => 'on|off',
@@ -39,10 +39,12 @@ has time => sub { ZnapZend::Time->new(timeWarp=>shift->timeWarp); };
 has backupSets => sub { [] };
 
 ### private functions ###
-my $splitHostDataSet = sub { return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/); };
+our $splitHostDataSet = sub {
+    return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
+};
 
 ### private methods ###
-my $checkBackupPlan = sub {
+our $checkBackupPlan = sub {
     my $self = shift;
     my $backupPlan = lc shift;
     my $returnBackupPlan;
@@ -71,7 +73,7 @@ my $checkBackupPlan = sub {
     return $returnBackupPlan;
 };
 
-my $checkBackupSets = sub {
+our $checkBackupSets = sub {
     my $self = shift;
 
     for my $backupSet (@{$self->backupSets}){
@@ -161,7 +163,7 @@ my $checkBackupSets = sub {
     return 1;
 };
 
-my $getBackupSet = sub {
+our $getBackupSet = sub {
     my $self = shift;
     my $enabledOnly = shift;
     # The recursion setting allows to find datasets under the named one

--- a/lib/ZnapZend/Time.pm
+++ b/lib/ZnapZend/Time.pm
@@ -45,21 +45,22 @@ has scrubTimeFilter => sub { qr/[A-Z][a-z]{2}\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}\s+\d
 has scrubTimeFormat => sub { q{%b %d %H:%M:%S %Y} };
 has timeWarp        => sub { undef };
 
-my $intervalToTimestamp = sub {
+### private methods ###
+our $intervalToTimestamp = sub {
     my $time = shift;
     my $interval = shift;
 
     return $interval * (int($time / $interval) + 1);
 };
 
-my $timeToTimestamp = sub {
+our $timeToTimestamp = sub {
     my $self = shift;
     my ($time, $unit) = @_;
 
     return $time * $self->unitFactors->{$unit};
 };
 
-my $getSnapshotTimestamp = sub {
+our $getSnapshotTimestamp = sub {
     my $self = shift;
     my $snapshot = shift;
     my $timeFormat = shift;

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -26,10 +26,15 @@ has zLog            => sub { Mojo::Exception->throw('zLog must be specified at c
 has priv            => sub { my $self = shift; [$self->rootExec ? split(/ /, $self->rootExec) : ()] };
 
 ### private functions ###
-my $splitHostDataSet     = sub { return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/); };
-my $splitDataSetSnapshot = sub { return ($_[0] =~ /^([^\@]+)\@([^\@]+)$/); };
+our $splitHostDataSet     = sub {
+    return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
+};
 
-my $shellQuote = sub {
+our $splitDataSetSnapshot = sub {
+    return ($_[0] =~ /^([^\@]+)\@([^\@]+)$/);
+};
+
+our $shellQuote = sub {
     my @return;
 
     for my $group (@_){
@@ -43,7 +48,8 @@ my $shellQuote = sub {
     return join '|', @return;
 };
 
-my $buildRemoteRefArray = sub {
+### private methods ###
+our $buildRemoteRefArray = sub {
     my $self = shift;
     my $remote = shift;
 
@@ -54,14 +60,14 @@ my $buildRemoteRefArray = sub {
     return @_;
 };
 
-my $buildRemote = sub {
+our $buildRemote = sub {
     my $self = shift;
     my @list = $self->$buildRemoteRefArray(@_);
 
     return @{$list[0]};
 };
 
-my $scrubZpool = sub {
+our $scrubZpool = sub {
     my $self = shift;
     my $startstop = shift;
     my $zpool = shift;


### PR DESCRIPTION
Solution: change file-scoped private functions and methods from "my" to "our"

Signed-off-by: Jim Klimov <jimklimov@gmail.com>

Note for reviewers: I am really not sure if this scoping keywork change would have any adverse effects. A quick local run of self-tests does not seem to expose any issues, let's see what Travis would say.