### PR TITLE
avoid using uninitialized $dataSet in string concatenation

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -133,7 +133,9 @@ my $refreshBackupPlans = sub {
     my $inherit = shift;
     my $dataSet = shift;
 
-    $self->zLog->info('refreshing backup plans for dataset "' . $dataSet . '" ...');
+    $self->zLog->info('refreshing backup plans' .
+	    (defined($dataSet) ? ' for dataset "' . $dataSet . '"' : '') .
+	    ' ...');
     $self->backupSets($self->zConfig->getBackupSetEnabled($recurse, $inherit, $dataSet));
 
     ($self->backupSets && @{$self->backupSets})


### PR DESCRIPTION
fixes the following warning when run with no arguments:

```
Nov 08 12:28:23 znapzend[29518]: Use of uninitialized value $dataSet in concatenation (.) or string at /usr/lib/x86_64-linux-gnu/ZnapZend.pm line 136.
```