### PR TITLE
Fix backup replication of inherited-config datasets

### DIFF
--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -740,7 +740,23 @@ sub getDataSetProperties {
                     }
                     if (defined($cachedInheritance{$tail_inheritKey}) && 1 == $cachedInheritance{$tail_inheritKey}) {
                         # This attr comes from a local source
-                        $properties{$key} = $value;
+                        if ( $key =~ /^dst_[^_]+$/ ) {
+                            # Rewrite destination dataset name shifted same as
+                            # this inherited source ($srcds) compared to its
+                            # ancestor which the config is inherited from ($tail
+                            # in the currently active sanity-checked conditions).
+                            if ($srcds =~ /^$tail\/(.+)$/) {
+                                print STDERR "=== getDataSetProperties(): Shifting destination name in config for dataset '$srcds' with configuration inherited from '$tail' : after '$value' will append '/$1'\n" if $self->debug;
+                                $properties{$key} = $value . "/" . $1;
+                            } else {
+                                # Abort if we can not decide well (better sadly
+                                # safe than very-sorry). Not sure if we can get
+                                # here... maybe by some zfs clones and promotion?
+                                die "The dataset '$srcds' with configuration inherited from '$tail' does not have the latter as ancestor, can't decide how to shift the destination dataset names";
+                            }
+                        } else {
+                            $properties{$key} = $value;
+                        }
                     }
                 } else {
                     # See some other $props...

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -629,6 +629,9 @@ sub getDataSetProperties {
                 $srcdsParent =~ s,/[^/]+$,,; # chop off the tail (if any - none on root datasets)
                 if (defined($cachedInheritance{"$srcdsParent\tattr:source"})) {
                     if ($prevSkipped_srcds ne $srcds && $self->debug) {
+                        # Even if we recurse+inherit, we do not need to return
+                        # dozens of backup configurations, one for each child.
+                        # The backup activity would recurse from the topmost.
                         print STDERR "=== getDataSetProperties(): SKIP: '$srcds' "
                             . "because parent config '$srcdsParent' is already listed ("
                             . $cachedInheritance{"$srcdsParent\tattr:source"} .")\n";


### PR DESCRIPTION
Before this, they were trying to replicate into the original (parent) `dst_N` rather than into a properly shifted one.