### PR TITLE
do not send intermediate snapshots

### DIFF
--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -368,7 +368,7 @@ sub sendRecvSnapshots {
 
     my @cmd;
     if ($lastCommon){
-        @cmd = ([@{$self->priv}, 'zfs', 'send', @sendOpt, '-I', $lastCommon, $lastSnapshot]);
+        @cmd = ([@{$self->priv}, 'zfs', 'send', @sendOpt, '-i', $lastCommon, $lastSnapshot]);
     }
     else{
         @cmd = ([@{$self->priv}, 'zfs', 'send', @sendOpt, $lastSnapshot]);


### PR DESCRIPTION
Hi,

it seems znapzend is using `zfs send -I` to send snapshots to destination. We found this to be surprising, since it includes intermediate snapshots (in our setup we utilise snapshots taken on the source for other purposes than backup, eg. synchronizing most current state to other production nodes). Consider the following setup:

```
% znapzendzetup create SRC '5min=>30sec' buildpool/zztest/src DST '5min=>30sec' buildpool/zztest/dst
*** backup plan: buildpool/zztest/src ***
           dst_0 = buildpool/zztest/dst
      dst_0_plan = 5minutes=>30seconds
         enabled = on
         mbuffer = off
    mbuffer_size = 1G
   post_znap_cmd = off
    pre_znap_cmd = off
       recursive = off
             src = buildpool/zztest/src
        src_plan = 5minutes=>30seconds
        tsformat = %Y-%m-%d-%H%M%S
      zend_delay = 0

Do you want to save this backup set [y/N]? y
NOTE: if you have modified your configuration, send a HUP signal
(pkill -HUP znapzend) to your znapzend daemon for it to notice the change.
```
... wait for znapzend to operate the first time ...
```
terra ~ % zfs list -rt all buildpool/zztest
NAME                                     USED  AVAIL  REFER  MOUNTPOINT
buildpool/zztest                          72K   890G    24K  legacy
buildpool/zztest/dst                      24K   890G    24K  legacy
buildpool/zztest/dst@2019-11-15-151000     0B      -    24K  -
buildpool/zztest/src                      24K   890G    24K  legacy
buildpool/zztest/src@2019-11-15-151000     0B      -    24K  -
```
then take a snapshot manually:
```
terra ~ % zfs snapshot buildpool/zztest/src@manual-snapshot
```

What we expected to happen here is that the manually taken snapshot is not sent to DST, but because of `-I`, it actually is. But there is nothing that would ever clean it up from there (even if it was eventually destroyed on source). But `-I` happily sends all the intermediate snapshots too so `manual-snapshot` also ends up on DST:
```
terra ~ % zfs list -rt all buildpool/zztest
NAME                                     USED  AVAIL  REFER  MOUNTPOINT
buildpool/zztest                          72K   890G    24K  legacy
buildpool/zztest/dst                      24K   890G    24K  legacy
buildpool/zztest/dst@2019-11-15-151000     0B      -    24K  -
buildpool/zztest/dst@manual-snapshot       0B      -    24K  -
buildpool/zztest/dst@2019-11-15-151030     0B      -    24K  -
buildpool/zztest/src                      24K   890G    24K  legacy
buildpool/zztest/src@2019-11-15-151000     0B      -    24K  -
buildpool/zztest/src@manual-snapshot       0B      -    24K  -
buildpool/zztest/src@2019-11-15-151030     0B      -    24K  -
```

I cannot see a reason to not use `-i` instead, to make sure that znapzend does not put snapshots it will never destroy onto DST. So here's a diff to avoid intermediate snapshots from ending up on DST, by changing `send -I` to `send -i`.