### PR TITLE
Introduce "znapzend -i/-I" for simplicity vs. "zfs send -i/-I" calls

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -16,6 +16,11 @@ sub main {
         qw(sudo pfexec rootExec=s daemonize pidfile=s logto=s loglevel=s),
         qw(runonce:s connectTimeout=s timeWarp=i nodelay autoCreation version),
         qw(forcedSnapshotSuffix=s),
+        qw(skipIntermediates|i sendIntermediates|I),
+            # Note: the intended usage is either via feature as done
+            # originally, or via shorthand -i/-I flags as mnemonical
+            # for "zfs send", so the longer variants --skipIntermediates
+            # vs. --sendIntermediates are not documented in the manpage.
         qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail recursive|r inherited)) or exit 1;
 
     $opts->{version} && do {
@@ -35,6 +40,14 @@ sub main {
             }
         }
         delete $opts->{features};
+    }
+
+    if (defined($opts->{sendIntermediates})) {
+        if ( (defined($opts->{skipIntermediates})) && ($opts->{skipIntermediates} != 0) ) {
+            warn "Options skipIntermediates and sendIntermediates are exclusive; and sendIntermediates wins!";
+        }
+        $opts->{skipIntermediates} = 0;
+        delete $opts->{sendIntermediates};
     }
 
     if (defined($opts->{runonce})) {
@@ -130,6 +143,7 @@ B<znapzend> [I<options>...]
  --features=x           comma separated list of features to be enabled
                         (detailed in man page):
     oracleMode recvu compressed lowmemRecurse zfsGetType skipIntermediates
+ -i/-I                  a "zfs send" compatible on/off for skipIntermediates
  --rootExec=x           exec zfs with this command to obtain root privileges
                         (sudo or pfexec)
  --connectTimeout=x     sets the ConnectTimeout for ssh commands

--- a/doc/znapzend.pod
+++ b/doc/znapzend.pod
@@ -24,6 +24,7 @@ B<znapzend> [I<options>...]
  --features=x           comma separated list of features to be enabled
                         (detailed in man page):
     oracleMode recvu compressed lowmemRecurse zfsGetType skipIntermediates
+ -i/-I                  a "zfs send" compatible on/off for skipIntermediates
  --rootExec=x           exec zfs with this command to obtain root privileges
                         (sudo or pfexec)
  --connectTimeout=x     sets the ConnectTimeout for ssh commands

--- a/man/znapzend.1
+++ b/man/znapzend.1
@@ -163,6 +163,7 @@ znapzend \- znapzend daemon
 \& \-\-features=x           comma separated list of features to be enabled
 \&                        (detailed in man page):
 \&    oracleMode recvu compressed lowmemRecurse zfsGetType skipIntermediates
+\& \-i/\-I                  a "zfs send" compatible on/off for skipIntermediates
 \& \-\-rootExec=x           exec zfs with this command to obtain root privileges
 \&                        (sudo or pfexec)
 \& \-\-connectTimeout=x     sets the ConnectTimeout for ssh commands

--- a/t/znapzend.t
+++ b/t/znapzend.t
@@ -144,6 +144,8 @@ is (runCommand(qw(--runonce=tank/source), '--features=oracleMode,recvu,compresse
     1, 'znapzend --features=oracleMode,recvu,compressed --runonce=tank/source succeeds');
 is (runCommand(qw(--runonce=tank/source), '--features=skipIntermediates'),
     1, 'znapzend --features=skipIntermediates --runonce=tank/source succeeds');
+is (runCommand(qw(--runonce=tank/source -i -I), '--features=skipIntermediates'),
+    1, 'znapzend --features=skipIntermediates --runonce=tank/source -i -I succeeds (should complain about both opposing flags used)');
 
 # Coverage for various failure codepaths
 $ENV{'ZNAPZENDTEST_ZFS_GET_DST0PRECMD_FAIL'} = '1';


### PR DESCRIPTION
A small user-friendly follow-up to #459