### PR TITLE
Add sendRaw as a feature to enable sending encrypted datasets without decrypting

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -8,7 +8,7 @@ use Pod::Usage;
 
 use ZnapZend;
 my $VERSION = '0.dev'; #VERSION
-my %featureMap = map { $_ => 1 } qw(pfexec sudo oracleMode recvu compressed lowmemRecurse zfsGetType skipIntermediates);
+my %featureMap = map { $_ => 1 } qw(pfexec sudo oracleMode recvu compressed sendRaw lowmemRecurse zfsGetType skipIntermediates);
 
 sub main {
     my $opts = {};
@@ -142,7 +142,7 @@ B<znapzend> [I<options>...]
  --forcedSnapshotSuffix=x  use non-generated snapshot suffix for this "run-once"
  --features=x           comma separated list of features to be enabled
                         (detailed in man page):
-    oracleMode recvu compressed lowmemRecurse zfsGetType skipIntermediates
+    oracleMode recvu compressed sendRaw lowmemRecurse zfsGetType skipIntermediates
  -i/-I                  a "zfs send" compatible on/off for skipIntermediates
  --rootExec=x           exec zfs with this command to obtain root privileges
                         (sudo or pfexec)
@@ -380,6 +380,17 @@ as reduces network bandwidth usage.
 
 The -L option is for large block support and -e is for embedded data
 support. These may require certain (Open)ZFS features to be enabled.
+
+=item sendRaw
+
+use 'sendRaw' to add option -w to zfs send commands
+
+For encrypted source datasets this instructs zfs not to decrypt
+before sending which results in a remote backup that can't be read
+without the encryption key/passphrase, useful when the remote isn't
+fully trusted or not physically secure. This option must be used
+consistently, raw incrementals cannot be based on non-raw snapshots
+and vice versa.
 
 =item skipIntermediates
 

--- a/doc/znapzend.pod
+++ b/doc/znapzend.pod
@@ -262,6 +262,17 @@ as reduces network bandwidth usage.
 The -L option is for large block support and -e is for embedded data
 support. These may require certain (Open)ZFS features to be enabled.
 
+=item sendRaw
+
+use 'sendRaw' to add option -w to zfs send commands
+
+For encrypted source datasets this instructs zfs not to decrypt
+before sending which results in a remote backup that can't be read
+without the encryption key/passphrase, useful when the remote isn't
+fully trusted or not physically secure. This option must be used
+consistently, raw incrementals cannot be based on non-raw snapshots
+and vice versa.
+
 =item skipIntermediates
 
 Enable the 'skipIntermediates' feature to send a single increment

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -27,6 +27,7 @@ has nodestroy               => sub { 0 };
 has oracleMode              => sub { 0 };
 has recvu                   => sub { 0 };
 has compressed              => sub { 0 };
+has sendRaw                 => sub { 0 };
 has skipIntermediates       => sub { 0 };
 has lowmemRecurse           => sub { 0 };
 has rootExec                => sub { q{} };
@@ -65,7 +66,8 @@ has zZfs => sub {
         recvu => $self->recvu, connectTimeout => $self->connectTimeout,
         lowmemRecurse => $self->lowmemRecurse, skipIntermediates => $self->skipIntermediates,
         rootExec => $self->rootExec, zfsGetType => $self->zfsGetType,
-        zLog => $self->zLog, compressed => $self->compressed);
+        zLog => $self->zLog, compressed => $self->compressed,
+        sendRaw => $self->sendRaw);
 };
 
 has zTime => sub { ZnapZend::Time->new(timeWarp=>shift->timeWarp) };

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -12,6 +12,7 @@ has nodestroy       => sub { 1 };
 has oracleMode      => sub { 0 };
 has recvu           => sub { 0 };
 has compressed      => sub { 0 };
+has sendRaw         => sub { 0 };
 has skipIntermediates => sub { 0 };
 has lowmemRecurse   => sub { 0 };
 has zfsGetType      => sub { 0 };
@@ -347,6 +348,7 @@ sub sendRecvSnapshots {
     my $recvOpt = $self->recvu ? '-uF' : '-F';
     my $incrOpt = $self->skipIntermediates ? '-i' : '-I';
     my @sendOpt = $self->compressed ? qw(-Lce) : ();
+    push @sendOpt, '-w' if $self->sendRaw;
 
     my $remote;
     my $mbufferPort;


### PR DESCRIPTION
Added as a feature in the same way as compressed and recvu. I think it might be better to have this feature defined with destinations and stored in the dataset attributes (so when sending to two remotes, one could be sent encrypted and the other not) but that applies to compressed and recvu as well so a bigger piece of work!