### PR TITLE
Do not back up from bogus snapshot datasets

### DIFF
--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -89,6 +89,17 @@ my $checkBackupSets = sub {
            next;
         }
 
+        if ( $dataSet =~ m/[\@]/ ) {
+            # If we are here, somebody fed us a snapshot in the list of
+            # datasets, which is likely a bug elsewhere in discovery.
+            # We do not want to fail whole backup below due to faulted
+            # dataSetExists() below, so just ignore this entry.
+            # If we really do get here, take a hard look at recursive
+            # and/or inherited modes for run-once.
+            print STDERR "#checkBackupSets# SKIP $backupSet->{src} because it is not a filesystem,volume. BUG: Should not get here.\n";# if $self->debug;
+            next;
+        }
+
         for my $prop (keys %{$self->mandProperties}){
             exists $backupSet->{$prop} || do {
                 $self->zLog->info("WARNING: property $prop not set on backup for " . $backupSet->{src} . ". Skipping to next dataset");

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -89,6 +89,9 @@ my $scrubZpool = sub {
 
 ### public methods ###
 sub dataSetExists {
+    # Note: Despite the "dataset" in the name, this routine only asks about
+    # the "live datasets" (filesystem,volume) and not snapshots which are
+    # also a type of dataset in ZFS terminology. See snapshotExists() below.
     my $self = shift;
     my $dataSet = shift;
     my $remote;
@@ -134,6 +137,9 @@ sub snapshotExists {
 }
 
 sub listDataSets {
+    # Note: Despite the "dataset" in the name, this routine only asks about
+    # the "live datasets" (filesystem,volume) and not snapshots which are
+    # also a type of dataset in ZFS terminology. See listSnapshots() below.
     my $self = shift;
     my $remote = shift;
     my $rootDataSets = shift; # May be not passed, or may be a string, or an array of strings

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -272,8 +272,9 @@ sub createSnapshot {
     Mojo::Exception->throw("ERROR: cannot create snapshot $dataSet");
 }
 
-# known limitation: snapshots from subdatasets have to be destroyed individually
 sub destroySnapshots {
+    # known limitation: snapshots from subdatasets have to be
+    # destroyed individually on some ZFS implementations
     my $self = shift;
     my @toDestroy = ref($_[0]) eq "ARRAY" ? @{$_[0]} : ($_[0]);
     my %toDestroy;


### PR DESCRIPTION
Hit an issue on a system that had some mid-way state of codebase (where I developed other znapzend patches) that it somehow listed a snapshot into the array of datasets to back up. This failed when requesting its properties (it is not a "filesystem,volume" type for zfs call) and aborted the backup.

The original call was with non-mainstream mix of "runonce recursive inherited" so maybe there is some bug there that I did not yet look at further. In fact maybe it was some bug in the older code version abandoned on that system that may be no longer present in committed sources - it is complicated to check better because that box is away from internet and does not have git tools.

Anyway, we can alert the users if their code ever gets into this state (so the bug can be confirmed if it happens in the wild), and skip the snapshots from the list they should not be in.

Note: First I considered adding the is/is-not a snapshot checks based on characters in `$dataSet` string into `datasetExists()` and many others near it, but chose against it. Let ZFS of the host's version decide generally what is or is not a requested dataset type, now that there are also bookmarks etc. in the mix.