### PR TITLE
Fix extracting git tag in Pipeline and push v0.20.0 to Docker Hub again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
     - name: Login to image registry
       run: docker login -u ${{ secrets.DOCKER_HUB_USERNAME }} -p ${{ secrets.DOCKER_HUB_PASSWORD }}
     - name: Build runtime image
-      run: docker build --target runtime -t ${{ github.repository }}:${GITHUB_REF#refs/heads/} .
+      run: docker build --target runtime -t ${{ github.repository }}:${GITHUB_REF##*/} .
     - name: Run test within image
       run: docker build --target test .
     - name: Push runtime image
-      run: docker push ${{ github.repository }}:${GITHUB_REF#refs/heads/}
+      run: docker push ${{ github.repository }}:${GITHUB_REF##*/}


### PR DESCRIPTION
 The latest 0.20.0 release job failed to publish to Docker: https://github.com/oetiker/znapzend/runs/527798365

This PR should fix this for the future, examples here:
```shell
$ GITHUB_REF=refs/tags/0.3.1-rc1asdfasdf
$ echo ${GITHUB_REF#refs/heads/} # this one doesn't work, that's why the Docker build failed in the job
refs/tags/0.3.1-rc1asdfasdf
$ echo ${GITHUB_REF##*/}
0.3.1-rc1asdfasdf
```
After that, either re-tag v0.20.0 to this merge-commit, or bump to v0.20.1, or just cheat a bit locally with
```
docker pull oetiker/znapzend:master
docker tag oetiker/znapzend:master oetiker/znapzend:v0.20.0
docker push oetiker/znapzend:v0.20.0
```
since the master tag got built and pushed successfully and it's currently the latest merge commit in master branch.

Whatever you prefer ;)