### PR TITLE
Fix perl 5.10 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
 ##### Runtime image
 FROM docker.io/library/alpine:${ALPINE_VERSION} as runtime
 
-ARG PERL_VERSION=5.30.3-r2
+ARG PERL_VERSION=5.30.3-r0
 
 RUN \
   # nano is for the interactive "edit" command in znapzendzetup if preferred over vi

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
 ##### Runtime image
 FROM docker.io/library/alpine:${ALPINE_VERSION} as runtime
 
-ARG PERL_VERSION=5.30.1-r0
+ARG PERL_VERSION=5.30.3-r2
 
 RUN \
   # nano is for the interactive "edit" command in znapzendzetup if preferred over vi

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
   # nano is for the interactive "edit" command in znapzendzetup if preferred over vi
   apk add --no-cache zfs curl bash autoconf automake nano perl=${PERL_VERSION} openssh && \
   # mbuffer is not in main currently
-  apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ mbuffer && \
+  apk add --no-cache --repository http://dl-3.alpinelinux.org/alpine/edge/community/ mbuffer && \
   ln -s /dev/stdout /var/log/syslog && \
   ln -s /usr/bin/perl /usr/local/bin/perl
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,14 +83,17 @@ if test "x$PERL" != "x"; then
         AC_MSG_RESULT(no);
         AC_MSG_ERROR(at least version $ac_perl_version is required to run mojolicious at all)
     else
+        MOJOLICIOUS_VERSION_CONSTRAINT=", '< 8.44'"
         AC_MSG_RESULT(ok);
     fi
   else
     AC_MSG_RESULT(ok);
+    MOJOLICIOUS_VERSION_CONSTRAINT=""
   fi
 else
   AC_MSG_ERROR(could not find perl)
 fi
+AC_SUBST(MOJOLICIOUS_VERSION_CONSTRAINT)
 
 
 AC_MSG_CHECKING(is perl reasonably complete)
@@ -205,6 +208,7 @@ AC_DEFINE_UNQUOTED(LIBDIR, "${conftemp}", [Default path for system libraries])
 AC_SUBST(LIBDIR)
 
 AC_CONFIG_FILES([
+    cpanfile
     Makefile
     thirdparty/Makefile
     lib/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -84,7 +84,6 @@ if test "x$PERL" != "x"; then
         AC_MSG_ERROR(at least version $ac_perl_version is required to run mojolicious at all)
     else
         MOJOLICIOUS_VERSION_CONSTRAINT=", '< 8.44'"
-        AC_MSG_RESULT(ok);
     fi
   else
     AC_MSG_RESULT(ok);
@@ -94,7 +93,9 @@ else
   AC_MSG_ERROR(could not find perl)
 fi
 AC_SUBST(MOJOLICIOUS_VERSION_CONSTRAINT)
-
+if test -n "$MOJOLICIOUS_VERSION_CONSTRAINT" ; then
+    AC_MSG_WARN(The available Perl version limits mojolicious version$MOJOLICIOUS_VERSION_CONSTRAINT)
+fi
 
 AC_MSG_CHECKING(is perl reasonably complete)
 if $PERL -MExtUtils::MakeMaker -e '' 2>/dev/null; then

--- a/configure.ac
+++ b/configure.ac
@@ -63,14 +63,28 @@ fi
 AC_SUBST(URL_CAT)
 
 
-ac_perl_version="5.10.1"
+# Note: current Mojolicious as of mid-2020 requires even Perl 5.16+
+# Older versions needed 5.10.1+
+ac_perl_version="5.16.0"
 
 if test "x$PERL" != "x"; then
   AC_MSG_CHECKING(for perl version greater than or equal to $ac_perl_version)
   $PERL -e "use $ac_perl_version;" >/dev/null 2>&1
   if test $? -ne 0; then
     AC_MSG_RESULT(no);
-    AC_MSG_ERROR(at least version 5.10.1 is required to run mojolicious)
+    AC_MSG_WARN(at least version $ac_perl_version is required to run modern mojolicious)
+
+    # re-check for older distributions minimal support
+    ac_perl_version="5.10.1"
+
+    AC_MSG_CHECKING(for perl version greater than or equal to $ac_perl_version)
+    $PERL -e "use $ac_perl_version;" >/dev/null 2>&1
+    if test $? -ne 0; then
+        AC_MSG_RESULT(no);
+        AC_MSG_ERROR(at least version $ac_perl_version is required to run mojolicious at all)
+    else
+        AC_MSG_RESULT(ok);
+    fi
   else
     AC_MSG_RESULT(ok);
   fi

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,0 @@
-requires 'Mojolicious';
-requires 'Mojo::IOLoop::ForkCall';
-requires 'Scalar::Util', '>= 1.45';
-requires 'Test::Exception';

--- a/cpanfile.in
+++ b/cpanfile.in
@@ -1,0 +1,4 @@
+requires 'Mojolicious' @MOJOLICIOUS_VERSION_CONSTRAINT@;
+requires 'Mojo::IOLoop::ForkCall';
+requires 'Scalar::Util', '>= 1.45';
+requires 'Test::Exception';


### PR DESCRIPTION
Mojolicious released a new version a couple of months ago; the last release with support for perl 5.10 was 8.43: https://github.com/mojolicious/mojo/commit/52a237a813e778a998caa99e71dd8c8d5fd0cd2a

We can bolt using mojolicious-8.43 for older hosts with perl-5.10 however, at least for as long as it suffices (znapzend does not move THAT fast to require bleeding edge dependencies).