### PR TITLE
Support --autoCreation for sendRaw feature

### DIFF
--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -183,7 +183,7 @@ my $refreshBackupPlans = sub {
                 $backupSet->{"dst_$key" . '_valid'} =
                     $self->zZfs->dataSetExists($backupSet->{"dst_$key"}) or do {
 
-                    if ($self->autoCreation) {
+                    if ($self->autoCreation && !$self->sendRaw) {
                         my ($zpool) = $backupSet->{"dst_$key"} =~ /(^[^\/]+)\//;
 
                         # check if we can access destination zpool, if so create parent dataset
@@ -317,7 +317,7 @@ my $sendRecvCleanup = sub {
         }
 
         #recheck non valid dst as it might be online, now
-        if (!$backupSet->{"dst_$key" . '_valid'}) {
+        if (!$backupSet->{"dst_$key" . '_valid'} && !$self->sendRaw) {
 
             $backupSet->{"dst_$key" . '_valid'} =
                 $self->zZfs->dataSetExists($backupSet->{"dst_$key"}) or do {

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -352,7 +352,8 @@ sub sendRecvSnapshots {
     my $mbuffer = shift;
     my $mbufferSize = shift;
     my $snapFilter = $_[0] || qr/.*/;
-    my $recvOpt = $self->recvu ? '-uF' : '-F';
+    my @recvOpt = $self->recvu ? qw(-u) : ();
+    push @recvOpt, '-F' if !$self->sendRaw;
     my $incrOpt = $self->skipIntermediates ? '-i' : '-I';
     my @sendOpt = $self->compressed ? qw(-Lce) : ();
     push @sendOpt, '-w' if $self->sendRaw;
@@ -391,7 +392,7 @@ sub sendRecvSnapshots {
         my $recvPid;
 
         my @recvCmd = $self->$buildRemoteRefArray($remote, [$mbuffer, @{$self->mbufferParam},
-            $mbufferSize, '-4', '-I', $mbufferPort], [@{$self->priv}, 'zfs', 'recv', $recvOpt, $dstDataSetPath]);
+            $mbufferSize, '-4', '-I', $mbufferPort], [@{$self->priv}, 'zfs', 'recv', @recvOpt, $dstDataSetPath]);
 
         my $cmd = $shellQuote->(@recvCmd);
 
@@ -458,7 +459,7 @@ sub sendRecvSnapshots {
     }
     else {
         my @mbCmd = $mbuffer ne 'off' ? ([$mbuffer, @{$self->mbufferParam}, $mbufferSize]) : () ;
-        my $recvCmd = [@{$self->priv}, 'zfs', 'recv' , $recvOpt, $dstDataSetPath];
+        my $recvCmd = [@{$self->priv}, 'zfs', 'recv' , @recvOpt, $dstDataSetPath];
 
         push @cmd,  $self->$buildRemoteRefArray($remote, @mbCmd, $recvCmd);
 


### PR DESCRIPTION
This change addresses these issues:
- Snapshot send encrypted to a backup destination for the first time fails #495
- Raw (encrypted) send failure #491

The issue is the way how znapzend handles destinations that do not exist. This isn't compatible with how ZFS handles a raw encrypted stream. This behaviour is introduced in PL #468 when the sendRaw feature is introduced. ZnapZend always uses the -F receive option that cannot be used to destroy an encrypted filesystem or overwrite an unencrypted one with an encrypted one. And ZnapZend creates an unencrypted destination dataset when --autoCreation is used. This triggers a ZFS error when sending a snapshot using a raw encrypted stream when the destination doesn't exist.

Changes in this PL:
- Do not use the -F receive option when sendRaw feature is used
- Do not create an unencrypted destination dataset when the sendRaw feature and--autoCreation is used, but let ZFS automatically take care of this.
- Do not send snapshots to the destination when the sendRaw feature is used and --autoCreation is omitted and the destination dataset doesn't exist.

This way the behaviour of --autoCreation is the same for normal streams and raw encrypted streams, and all information displayed to the user about destinations that do not exist and how to address this are still valid.