### PR TITLE
Modernize #384 : More flexible handling of offline destinations

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -21,7 +21,9 @@ sub main {
             # originally, or via shorthand -i/-I flags as mnemonical
             # for "zfs send", so the longer variants --skipIntermediates
             # vs. --sendIntermediates are not documented in the manpage.
-        qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail recursive|r inherited)) or exit 1;
+        qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail recursive|r inherited),
+        qw(cleanOffline)
+        ) or exit 1;
 
     $opts->{version} && do {
         print "znapzend version $VERSION\n";
@@ -153,6 +155,7 @@ B<znapzend> [I<options>...]
                         by x seconds
  --skipOnPreSnapCmdFail skip snapshots if the pre-snap-command fails
  --skipOnPreSendCmdFail skip replication if the pre-send-command fails
+ --cleanOffline         clean up source snapshots even if a destination was offline
 
 =head1 DESCRIPTION
 
@@ -493,6 +496,13 @@ defined and the command returns a non-zero exit code or is killed by a signal.
 Prevent snapshots of a dataset from being replicated to a destination when
 it has a B<pre-snap-command> defined and the command returns a non-zero exit
 code or is killed by a signal.
+
+=item B<--cleanOffline>
+
+Clean snapshots of a source dataset even if one or more destination datasets failed during replication.
+The most recent common snapshot for each destination will not be deleted, but this is a
+potentially dangerous option. If the preserved snapshot somehow gets deleted from the
+destination, it may require a full re-replication the next time it is online.
 
 =back
 

--- a/doc/znapzend.pod
+++ b/doc/znapzend.pod
@@ -34,6 +34,7 @@ B<znapzend> [I<options>...]
                         by x seconds
  --skipOnPreSnapCmdFail skip snapshots if the pre-snap-command fails
  --skipOnPreSendCmdFail skip replication if the pre-send-command fails
+ --cleanOffline         clean up source snapshots even if a destination was offline
 
 =head1 DESCRIPTION
 
@@ -374,6 +375,13 @@ defined and the command returns a non-zero exit code or is killed by a signal.
 Prevent snapshots of a dataset from being replicated to a destination when
 it has a B<pre-snap-command> defined and the command returns a non-zero exit
 code or is killed by a signal.
+
+=item B<--cleanOffline>
+
+Clean snapshots of a source dataset even if one or more destination datasets failed during replication.
+The most recent common snapshot for each destination will not be deleted, but this is a
+potentially dangerous option. If the preserved snapshot somehow gets deleted from the
+destination, it may require a full re-replication the next time it is online.
 
 =back
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -359,7 +359,7 @@ my $sendRecvCleanup = sub {
                 local $@;
                 eval {
                     local $SIG{__DIE__};
-                    $self->zZfs->sendRecvSnapshots($srcDataSet, $dstDataSet,
+                    $self->zZfs->sendRecvSnapshots($srcDataSet, $dstDataSet, $dst,
                         $backupSet->{mbuffer}, $backupSet->{mbuffer_size}, $backupSet->{snapSendFilter});
                 };
                 if (my $err = $@){

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -489,7 +489,7 @@ my $sendRecvCleanup = sub {
                 for my $dst (sort grep { /^dst_[^_]+$/ } keys %$backupSet){
                     my $dstDataSet = $backupSet->{src};
                     $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
-                    my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($backupSet->{src}, $dstDataSet, $dst);
+                    my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($backupSet->{src}, $dstDataSet, $dst, $backupSet->{snapCleanFilter});
                     if ($recentCommon) {
                         $self->zLog->debug('not cleaning up ' . $recentCommon . ' recursively because it is needed by ' . $dstDataSet);
                         @{$toDestroy} = grep { $recentCommon ne $_ } @{$toDestroy};
@@ -549,7 +549,7 @@ my $sendRecvCleanup = sub {
             for my $dst (sort grep { /^dst_[^_]+$/ } keys %$backupSet){
                 my $dstDataSet = $srcDataSet;
                 $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
-                my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($srcDataSet, $dstDataSet, $dst);
+                my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($srcDataSet, $dstDataSet, $dst, $backupSet->{snapCleanFilter});
                 if ($recentCommon) {
                     $self->zLog->debug('not cleaning up ' . $recentCommon . ' because it is needed by ' . $dstDataSet);
                     @{$toDestroy} = grep { $recentCommon ne $_ } @{$toDestroy};

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -49,6 +49,7 @@ has timeWarp                => sub { undef };
 has nodelay                 => sub { 0 };
 has skipOnPreSnapCmdFail    => sub { 0 };
 has skipOnPreSendCmdFail    => sub { 0 };
+has cleanOffline            => sub { 0 };
 has backupSets              => sub { [] };
 
 has zConfig => sub {
@@ -455,14 +456,15 @@ my $sendRecvCleanup = sub {
     }
 
     #cleanup source
-    if (scalar(@sendFailed) > 0) {
+    if (scalar(@sendFailed) > 0 and not $self->cleanOffline) {
         $self->zLog->warn('ERROR: suspending cleanup source dataset because '
             . scalar(@sendFailed) . ' send task(s) failed:');
         foreach my $errmsg (@sendFailed) {
             $self->zLog->warn(' +-->   ' . $errmsg);
         }
     }
-    else{
+    else {
+        # If "not sendFailed" or "cleanOffline requested"...
         # cleanup source according to backup schedule
         if ($backupSet->{recursive} eq 'on') {
             # First we try to recursively (and atomically quickly)
@@ -477,21 +479,55 @@ my $sendRecvCleanup = sub {
             $toDestroy = $self->zTime->getSnapshotsToDestroy(\@snapshots,
                          $backupSet->{srcPlanHash}, $backupSet->{tsformat}, $timeStamp);
 
-            $self->zLog->debug('cleaning up snapshots recursively under ' . $backupSet->{src});
-            {
-                local $@;
-                eval {
-                    local $SIG{__DIE__};
-                    $self->zZfs->destroySnapshots($toDestroy, 1);
-                };
-                if ($@){
-                    if (blessed $@ && $@->isa('Mojo::Exception')){
-                        $self->zLog->warn($@->message);
-                    }
-                    else{
-                        $self->zLog->warn($@);
+            # preserve most recent common snapshots for each destination
+            # (including offline destinations for which last-known sync
+            # snapshot name is saved in properties of the source policy)
+            my $doClean = 1;
+
+            if (scalar($toDestroy) > 0) {
+                # Check if any death-rowed snapshots need protection
+                for my $dst (sort grep { /^dst_[^_]+$/ } keys %$backupSet){
+                    my $dstDataSet = $backupSet->{src};
+                    $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
+                    my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($backupSet->{src}, $dstDataSet, $dst);
+                    if ($recentCommon) {
+                        $self->zLog->debug('not cleaning up ' . $recentCommon . ' recursively because it is needed by ' . $dstDataSet);
+                        @{$toDestroy} = grep { $recentCommon ne $_ } @{$toDestroy};
+                    } elsif (scalar(@sendFailed) > 0) {
+                        # If we are here, "--cleanOffline" was requested,
+                        # and at least one destination is indeed offline,
+                        # but it is not safe in current situation regarding
+                        # last known sync points...
+                        $self->zLog->warn('ERROR: suspending recursive cleanup of ' . $backupSet->{src} . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
+                        $doClean = 0;
                     }
                 }
+            }
+
+            if (scalar($toDestroy) == 0) {
+                $self->zLog->debug('got an empty toDestroy list for cleaning up snapshots recursively under ' . $backupSet->{src});
+                $doClean = 0;
+            }
+
+            if ($doClean) {
+                $self->zLog->debug('cleaning up snapshots recursively under ' . $backupSet->{src});
+                {
+                    local $@;
+                    eval {
+                        local $SIG{__DIE__};
+                        $self->zZfs->destroySnapshots($toDestroy, 1);
+                    };
+                    if ($@){
+                        if (blessed $@ && $@->isa('Mojo::Exception')){
+                            $self->zLog->warn($@->message);
+                        }
+                        else{
+                            $self->zLog->warn($@);
+                        }
+                    }
+                } # scope
+            } else {
+                $self->zLog->debug('NOT cleaning up snapshots recursively under ' . $backupSet->{src});
             }
             $self->zLog->debug('now will look if there is anything to clean in children of ' . $backupSet->{src});
         }
@@ -499,6 +535,7 @@ my $sendRecvCleanup = sub {
         # See if there is anything remaining to clean up in child
         # datasets (if recursive snapshots are enabled) or just
         # this one dataset.
+        SRC_SET:
         for my $srcDataSet (@$srcSubDataSets){
             next if ($backupSet->{recursive} eq 'on' && $srcDataSet eq $backupSet->{src});
 
@@ -514,8 +551,15 @@ my $sendRecvCleanup = sub {
                 $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
                 my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($srcDataSet, $dstDataSet, $dst);
                 if ($recentCommon) {
-                    $self->zLog->debug('not cleaning up ' . $recentCommon . ' because it is the most recent common snapshot with ' . $dstDataSet);
+                    $self->zLog->debug('not cleaning up ' . $recentCommon . ' because it is needed by ' . $dstDataSet);
                     @{$toDestroy} = grep { $recentCommon ne $_ } @{$toDestroy};
+                } elsif (scalar(@sendFailed) > 0) {
+                    # If we are here, "--cleanOffline" was requested,
+                    # and at least one destination is indeed offline,
+                    # but it is not safe in current situation regarding
+                    # last known sync points...
+                    $self->zLog->warn('ERROR: suspending cleanup of ' . $srcDataSet . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
+                    next SRC_SET;
                 }
             }
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -393,7 +393,7 @@ my $sendRecvCleanup = sub {
             $toDestroy = $self->zTime->getSnapshotsToDestroy(\@snapshots,
                          $backupSet->{"dst$key" . 'PlanHash'}, $backupSet->{tsformat}, $timeStamp);
 
-            $self->zLog->debug('cleaning up snapshots recursively under ' . $backupSet->{$dst});
+            $self->zLog->debug('cleaning up snapshots recursively under destination ' . $backupSet->{$dst});
             {
                 local $@;
                 eval {
@@ -409,7 +409,7 @@ my $sendRecvCleanup = sub {
                     }
                 }
             }
-            $self->zLog->debug('now will look if there is anything to clean in children of ' . $backupSet->{$dst});
+            $self->zLog->debug('now will look if there is anything to clean in children of destination ' . $backupSet->{$dst});
         }
 
         #cleanup children of current destination
@@ -426,7 +426,7 @@ my $sendRecvCleanup = sub {
 
             next if (scalar (@{$toDestroy}) == 0);
 
-            $self->zLog->debug('cleaning up snapshots on ' . $dstDataSet);
+            $self->zLog->debug('cleaning up snapshots on destination ' . $dstDataSet);
             {
                 local $@;
                 eval {
@@ -491,26 +491,26 @@ my $sendRecvCleanup = sub {
                     $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
                     my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($backupSet->{src}, $dstDataSet, $dst, $backupSet->{snapCleanFilter});
                     if ($recentCommon) {
-                        $self->zLog->debug('not cleaning up ' . $recentCommon . ' recursively because it is needed by ' . $dstDataSet);
+                        $self->zLog->debug('not cleaning up source ' . $recentCommon . ' recursively because it is needed by ' . $dstDataSet);
                         @{$toDestroy} = grep { $recentCommon ne $_ } @{$toDestroy};
                     } elsif (scalar(@sendFailed) > 0) {
                         # If we are here, "--cleanOffline" was requested,
                         # and at least one destination is indeed offline,
                         # but it is not safe in current situation regarding
                         # last known sync points...
-                        $self->zLog->warn('ERROR: suspending recursive cleanup of ' . $backupSet->{src} . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
+                        $self->zLog->warn('ERROR: suspending recursive cleanup of source ' . $backupSet->{src} . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
                         $doClean = 0;
                     }
                 }
             }
 
             if (scalar($toDestroy) == 0) {
-                $self->zLog->debug('got an empty toDestroy list for cleaning up snapshots recursively under ' . $backupSet->{src});
+                $self->zLog->debug('got an empty toDestroy list for cleaning up source snapshots recursively under ' . $backupSet->{src});
                 $doClean = 0;
             }
 
             if ($doClean) {
-                $self->zLog->debug('cleaning up snapshots recursively under ' . $backupSet->{src});
+                $self->zLog->debug('cleaning up source snapshots recursively under ' . $backupSet->{src});
                 {
                     local $@;
                     eval {
@@ -527,9 +527,9 @@ my $sendRecvCleanup = sub {
                     }
                 } # scope
             } else {
-                $self->zLog->debug('NOT cleaning up snapshots recursively under ' . $backupSet->{src});
+                $self->zLog->debug('NOT cleaning up source snapshots recursively under ' . $backupSet->{src});
             }
-            $self->zLog->debug('now will look if there is anything to clean in children of ' . $backupSet->{src});
+            $self->zLog->debug('now will look if there is anything to clean in children of source ' . $backupSet->{src});
         }
 
         # See if there is anything remaining to clean up in child
@@ -551,24 +551,24 @@ my $sendRecvCleanup = sub {
                 $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
                 my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($srcDataSet, $dstDataSet, $dst, $backupSet->{snapCleanFilter});
                 if ($recentCommon) {
-                    $self->zLog->debug('not cleaning up ' . $recentCommon . ' because it is needed by ' . $dstDataSet);
+                    $self->zLog->debug('not cleaning up source ' . $recentCommon . ' because it is needed by ' . $dstDataSet);
                     @{$toDestroy} = grep { $recentCommon ne $_ } @{$toDestroy};
                 } elsif (scalar(@sendFailed) > 0) {
                     # If we are here, "--cleanOffline" was requested,
                     # and at least one destination is indeed offline,
                     # but it is not safe in current situation regarding
                     # last known sync points...
-                    $self->zLog->warn('ERROR: suspending cleanup of ' . $srcDataSet . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
+                    $self->zLog->warn('ERROR: suspending cleanup of source ' . $srcDataSet . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
                     next SRC_SET;
                 }
             }
 
             if (scalar (@{$toDestroy}) == 0) {
-                $self->zLog->debug('got nothing to clean in children of ' . $backupSet->{src});
+                $self->zLog->debug('got nothing to clean in children of source ' . $backupSet->{src});
                 next;
             }
 
-            $self->zLog->debug('cleaning up snapshots on ' . $srcDataSet);
+            $self->zLog->debug('cleaning up snapshots on source ' . $srcDataSet);
             {
                 local $@;
                 eval {

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -489,7 +489,7 @@ my $sendRecvCleanup = sub {
                 for my $dst (sort grep { /^dst_[^_]+$/ } keys %$backupSet){
                     my $dstDataSet = $backupSet->{src};
                     $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
-                    my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($backupSet->{src}, $dstDataSet, $dst, $backupSet->{snapCleanFilter});
+                    my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($backupSet->{src}, $dstDataSet, $dst, $backupSet->{snapCleanFilter}, ($backupSet->{recursive} eq 'on') );
                     if ($recentCommon) {
                         $self->zLog->debug('not cleaning up source ' . $recentCommon . ' recursively because it is needed by ' . $dstDataSet);
                         @{$toDestroy} = grep { $recentCommon ne $_ } @{$toDestroy};

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -345,6 +345,44 @@ sub lastAndCommonSnapshots {
         ? ${$srcSnapshots}[$i] : undef), scalar @$dstSnapshots);
 }
 
+sub mostRecentCommonSnapshot {
+    my $self = shift;
+    my $srcDataSet = shift;
+    my $dstDataSet = shift;
+    my $dstName = shift;
+
+    my $lastCommonSnapshot;
+    {
+        local $@;
+        eval {
+            local $SIG{__DIE__};
+            $lastCommonSnapshot = ($self->lastAndCommonSnapshots($srcDataSet, $dstDataSet))[1];
+        };
+        if ($@){
+            if (blessed $@ && $@->isa('Mojo::Exception')){
+                $self->zLog->warn($@->message);
+            }
+            else{
+                $self->zLog->warn($@);
+            }
+        }
+    }
+    if (not $lastCommonSnapshot){
+        my $srcSnapshots = $self->listSnapshots($srcDataSet);
+        my $i;
+        for ($i = $#{$srcSnapshots}; $i >= 0; $i--){
+            my $snapshot = ${$srcSnapshots}[$i];
+            my $properties = $self->getSnapshotProperties($snapshot);
+            if ($properties->{$dstName} and ($properties->{$dstName} eq $dstDataSet) and $properties->{$dstName . '_synced'}){
+                $lastCommonSnapshot = $snapshot;
+                last;
+            }
+        }
+    }
+    return $lastCommonSnapshot;
+}
+
+
 sub sendRecvSnapshots {
     my $self = shift;
     my $srcDataSet = shift;
@@ -863,6 +901,24 @@ sub deleteDataSetProperties {
     return 1;
 }
 
+sub getSnapshotProperties {
+    my $self = shift;
+    my $snapshot = shift;
+    my %properties;
+    my $propertyPrefix = $self->propertyPrefix;
+
+    my @cmd = (@{$self->priv}, qw(zfs get -H -s local -o), 'property,value', 'all', $snapshot);
+    print STDERR '# ' . join(' ', @cmd) . "\n" if $self->debug;
+    open my $props, '-|', @cmd or Mojo::Exception->throw('ERROR: could not get zfs properties');
+    while (my $prop = <$props>){
+        chomp $prop;
+        my ($key, $value) = $prop =~ /^\Q$propertyPrefix\E:(\S+)\s+(.+)$/ or next;
+        $properties{$key} = $value;
+    }
+
+    return \%properties;
+}
+
 sub setSnapshotProperties {
     my $self = shift;
     my $snapshot = shift;
@@ -1060,6 +1116,10 @@ destroys a single snapshot or a list of snapshots on localhost or a remote host,
 
 lists the last snapshot on source and the last common snapshot an source and destination and the number of snapshots found on the destination host
 
+=head2 mostRecentCommonSnapshot
+
+gets the name of the most recent common snapshot between source and destination, first by trying to get the actual snapshots, then by checking the dst_*_synced property on each source snapshot if the destination is offline
+
 =head2 sendRecvSnapshots
 
 sends snapshots to a different destination on localhost or a remote host
@@ -1075,6 +1135,10 @@ sets dataset properties
 =head2 deleteDataSetProperties
 
 deletes dataset properties
+
+=head2 getSnapshotProperties
+
+gets snapshot properties
 
 =head2 setSnapshotProperties
 

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -349,6 +349,7 @@ sub sendRecvSnapshots {
     my $self = shift;
     my $srcDataSet = shift;
     my $dstDataSet = shift;
+    my $dstName = shift; # name of the znapzend policy => attribute prefix
     my $mbuffer = shift;
     my $mbufferSize = shift;
     my $snapFilter = $_[0] || qr/.*/;
@@ -367,8 +368,14 @@ sub sendRecvSnapshots {
     my ($lastSnapshot, $lastCommon,$dstSnapCount)
         = $self->lastAndCommonSnapshots($srcDataSet, $dstDataSet, $snapFilter);
 
+    my %snapshotSynced = ($dstName, $dstDataSet,
+        $dstName . '_synced', 1);
     #nothing to do if no snapshot exists on source or if last common snapshot is last snapshot on source
-    return 1 if !$lastSnapshot || (defined $lastCommon && ($lastSnapshot eq $lastCommon));
+    return 1 if !$lastSnapshot;
+    if (defined $lastCommon && ($lastSnapshot eq $lastCommon)){
+        $self->setSnapshotProperties($lastCommon, \%snapshotSynced);
+        return 1;
+    }
 
     #check if snapshots exist on destination if there is no common snapshot
     #as this will cause zfs send/recv to fail
@@ -470,6 +477,7 @@ sub sendRecvSnapshots {
             . ($remote ? " on $remote" : '')) if !$self->noaction;
     }
 
+    $self->setSnapshotProperties($lastSnapshot, \%snapshotSynced);
     return 1;
 }
 
@@ -855,6 +863,23 @@ sub deleteDataSetProperties {
     return 1;
 }
 
+sub setSnapshotProperties {
+    my $self = shift;
+    my $snapshot = shift;
+    my $properties = shift;
+    my $propertyPrefix = $self->propertyPrefix;
+
+    return 0 if !$self->snapshotExists($snapshot);
+    for my $prop (keys %$properties){
+        my @cmd = (@{$self->priv}, qw(zfs set), "$propertyPrefix:$prop=$properties->{$prop}", $snapshot);
+        print STDERR '# ' . join(' ', @cmd) . "\n" if $self->debug;
+        system(@cmd)
+            && Mojo::Exception->throw("ERROR: could not set property $prop on $snapshot") if !$self->noaction;
+    }
+
+    return 1;
+}
+
 sub deleteBackupDestination {
     my $self = shift;
     my $dataSet = shift;
@@ -1050,6 +1075,10 @@ sets dataset properties
 =head2 deleteDataSetProperties
 
 deletes dataset properties
+
+=head2 setSnapshotProperties
+
+sets snapshot properties
 
 =head2 deleteBackupDestination
 

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -938,7 +938,7 @@ sub setSnapshotProperties {
     return 0 if !$self->snapshotExists($snapshot);
     for my $prop (keys %$properties){
         my @cmd = (@{$self->priv}, qw(zfs set), "$propertyPrefix:$prop=$properties->{$prop}", $snapshot);
-        print STDERR '# ' . join(' ', @cmd) . "\n" if $self->debug;
+        print STDERR '# ' . ($self->noaction ? "WOULD # " : "" ) . join(' ', @cmd) . "\n" if $self->debug;
         system(@cmd)
             && Mojo::Exception->throw("ERROR: could not set property $prop on $snapshot") if !$self->noaction;
     }

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -346,10 +346,14 @@ sub lastAndCommonSnapshots {
 }
 
 sub mostRecentCommonSnapshot {
+    # This is similar to lastAndCommonSnapshots() above, but considers not only
+    # the "live" information from a currently accessible destination, but as a
+    # fallback also the saved last-known-synced snapshot name.
+    # TODO: Add support for modifiable $snapshotFilter like appeared in master.
     my $self = shift;
     my $srcDataSet = shift;
     my $dstDataSet = shift;
-    my $dstName = shift;
+    my $dstName = shift; # name of the znapzend policy => attribute prefix
 
     my $lastCommonSnapshot;
     {
@@ -902,6 +906,12 @@ sub deleteDataSetProperties {
 }
 
 sub getSnapshotProperties {
+    # Note: this code originated as a clone of getDataSetProperties() but
+    # that routine grew a lot since then to support recursive, inherited,
+    # lowmem and other optional scenarios, and considering dataSet arg as
+    # an array of names. Some of those traits may get ported here at least
+    # for consistency, where they make sense for ZFS snapshot dataset type.
+    # TODO: Port inherit, recursive, zfsGetType options as applicable.
     my $self = shift;
     my $snapshot = shift;
     my %properties;

--- a/t/zfs
+++ b/t/zfs
@@ -241,6 +241,17 @@ ${prefix}org.znapzend:dst_0_enabled  off${srcenabledsuffix_0}
 ZFS_GET_END
     }
 
+    if ($srcname =~ /@/) {
+        # Test getting properties of (source) snapshots, to see the "synced"
+        # flags in place to find last common snapshots for offline destinations
+        print <<"ZFS_GET_END";
+${prefix}org.znapzend:dst_0_synced   1
+${prefix}org.znapzend:dst_a_synced   1
+${prefix}org.znapzend:dst_fail_synced   1
+ZFS_GET_END
+    }
+
+
 } # end of print_zfs_get()
 
 #print zfs command
@@ -380,6 +391,22 @@ for ($command){
         #if ($ARGV[6] && $ARGV[6] eq 'usedbysnapshots'){
         if ( $ARGSTR =~ /usedbysnapshots/ ){
             print "10G\n";
+            exit;
+        }
+
+        # Test getting properties of (source) snapshots, to see the "synced"
+        # flags in place to find last common snapshots for offline destinations
+        if ($ARGV[-1] && $ARGV[-1] =~ /@/){
+            my ($dataSet) = $ARGV[-1] =~ /([^@]*)@/;
+            exit if !(exists $dataSets{$dataSet} && $dataSets{$dataSet} eq 'src');
+            print<<"ZFS_GET_END";
+org.znapzend:dst_0            backup/destination
+org.znapzend:dst_0_synced     1
+org.znapzend:dst_a            root\@remote:remote/destination
+org.znapzend:dst_a_synced     1
+org.znapzend:dst_fail         backup/destfail
+org.znapzend:dst_fail_synced  1
+ZFS_GET_END
             exit;
         }
 

--- a/t/znapzend.t
+++ b/t/znapzend.t
@@ -209,6 +209,10 @@ is (runCommand(qw(--runonce=tank/source), '--features=zfsGetType'),
 $ENV{'ZNAPZENDTEST_ZFS_GET_TYPE_UNHANDLED'} = undef;
 $ENV{'ZNAPZENDTEST_ZPOOL_DEFAULT_listsnapshots'} = undef;
 
+# Test codepath for cleaning of snapshots even if destination is offline
+is (runCommand(qw(--cleanOffline --debug)),
+    1, 'znapzend --cleanOffline succeeds');
+
 # Note: test for daemonized mode are offloaded to another file
 
 done_testing;


### PR DESCRIPTION
This picks up commits proposed in #384 and applies them to current master branch and its logical/conceptual changes.

The code passed locally a `./test.sh` run and from the looks of it - should be reasonably safe for common use-cases, but there may be caveats for non-default runs with `--inherited` mode which I suspect can end up ignoring this protection at the moment (detailed in my comments to the original PR). 