### PR TITLE
Fix regression #479-bis

### DIFF
--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -103,9 +103,9 @@ my $checkBackupSets = sub {
             # dataSetExists() below, so just ignore this entry.
             # If we really do get here, take a hard look at recursive
             # and/or inherited modes for run-once.
-            print STDERR "#checkBackupSets# SKIP backupSet='" . $backupSet->{src} .
-                "' because it is not a filesystem,volume. " .
-                "BUG: Should not get here.\n";# if $self->debug;
+            $self->zLog->error( "#checkBackupSets# SKIP backupSet='"
+                . $backupSet->{src} ."' because it is not a filesystem,volume. "
+                . "BUG: Should not get here.");# if $self->debug;
             next;
         }
 

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -89,7 +89,7 @@ my $checkBackupSets = sub {
            next;
         }
 
-        if ( $dataSet =~ m/[\@]/ ) {
+        if ( $backupSet->{src} =~ m/[\@]/ ) {
             # If we are here, somebody fed us a snapshot in the list of
             # datasets, which is likely a bug elsewhere in discovery.
             # We do not want to fail whole backup below due to faulted

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -89,6 +89,17 @@ my $checkBackupSets = sub {
            next;
         }
 
+        if ( $dataSet =~ m/[\@]/ ) {
+            # If we are here, somebody fed us a snapshot in the list of
+            # datasets, which is likely a bug elsewhere in discovery.
+            # We do not want to fail whole backup below due to faulted
+            # dataSetExists() below, so just ignore this entry.
+            # If we really do get here, take a hard look at recursive
+            # and/or inherited modes for run-once.
+            print STDERR "#checkBackupSets# SKIP $backupSet->{src} because it is not a filesystem,volume. BUG: Should not get here.\n";# if $self->debug;
+            next;
+        }
+
         for my $prop (keys %{$self->mandProperties}){
             exists $backupSet->{$prop} || do {
                 $self->zLog->info("WARNING: property $prop not set on backup for " . $backupSet->{src} . ". Skipping to next dataset");

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -80,11 +80,13 @@ my $checkBackupSets = sub {
 
     for my $backupSet (@{$self->backupSets}){
 
-        # in case there is only one property on this dataset, which is the "enabled" and is set to "off"
-        # consider it a normal situation and do not even notify it. This situation will appear
-        # when there are descendants of recursive ZFS dataset that should be skipped.
-        # Note: backupSets will have at least the key "Src". Therefore, we need to skip the
-        # dataset if there are two properties and one of them is "enabled".
+        # In case there is only one property on this dataset, which is the
+        # "enabled" flag and is set to "off"; consider it a normal situation
+        # and do not even notify it. This situation will appear when there
+        # are descendants of recursive ZFS dataset that should be skipped.
+        # Note: backupSets will have at least the key "src". Therefore, we
+        # need to skip the dataset if there are two properties and one of
+        # them is "enabled".
         if (keys(%{$backupSet}) eq 2 && exists($backupSet->{"enabled"})){
            next;
         }

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -98,7 +98,9 @@ my $checkBackupSets = sub {
             # dataSetExists() below, so just ignore this entry.
             # If we really do get here, take a hard look at recursive
             # and/or inherited modes for run-once.
-            print STDERR "#checkBackupSets# SKIP $backupSet->{src} because it is not a filesystem,volume. BUG: Should not get here.\n";# if $self->debug;
+            print STDERR "#checkBackupSets# SKIP backupSet='" . $backupSet->{src} .
+                "' because it is not a filesystem,volume. " .
+                "BUG: Should not get here.\n";# if $self->debug;
             next;
         }
 


### PR DESCRIPTION
Restores the failsafe removed quickly in #480, this time applying proper variable naming to the checked item.