### PR TITLE
Tests cleanup - really test daemonized mode behaviors (complete nits for #500)

### DIFF
--- a/.github/workflows/spelling/whitelist.txt
+++ b/.github/workflows/spelling/whitelist.txt
@@ -110,6 +110,7 @@ CWORD
 CXX
 cygpath
 cygwin
+daemonization
 daemonize
 daemonized
 DAGOLDEN
@@ -253,6 +254,7 @@ Isources
 isrc
 Itank
 Ithirdparty
+ithreads
 Itimeout
 Iusbbackup
 Iuser
@@ -313,6 +315,7 @@ MPTZONEROOTS
 mvcmd
 mvprog
 MYMETA
+myprint
 mysql
 NAL
 namespace
@@ -349,6 +352,7 @@ pak
 passphrase
 passwordless
 perl
+perldoc
 pfexec
 php
 pid
@@ -430,6 +434,7 @@ sourced
 sourceforge
 sourcemissing
 sourcetype
+SPAMALOT
 src
 srcame
 srcdir

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -146,6 +146,10 @@ sub main {
     $opts->{man} && pod2usage(-exitstatus => 0, -verbose => 2);
 
     my $znapzend = ZnapZend->new($opts);
+
+### RM_COMM_4_TEST_main ###  # remove ### RM_COMM_4_TEST_main ### comments for testing purpose.
+### RM_COMM_4_TEST_main ###  return $znapzend->start;
+
     $znapzend->start;
 
     return 1;

--- a/cpanfile.in
+++ b/cpanfile.in
@@ -1,4 +1,7 @@
 requires 'Mojolicious' @MOJOLICIOUS_VERSION_CONSTRAINT@;
 requires 'Mojo::IOLoop::ForkCall';
 requires 'Scalar::Util', '>= 1.45';
+requires 'Test::SharedFork';
 requires 'Test::Exception';
+requires 'Test::More';
+requires 'Test::Builder';

--- a/cpanfile.in
+++ b/cpanfile.in
@@ -4,4 +4,3 @@ requires 'Scalar::Util', '>= 1.45';
 requires 'Test::SharedFork';
 requires 'Test::Exception';
 requires 'Test::More';
-requires 'Test::Builder';

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -1288,10 +1288,10 @@ sub start {
         $self->$createWorkers;
     };
 
-    print STDERR "znapzend (PID=$$) Refreshing backup plans...\n";
+    print STDERR "znapzend (PID=$$) Refreshing backup plans...\n" if $self->debug;
     $self->$refreshBackupPlans($self->recursive, $self->inherited, $self->dataset);
 
-    print STDERR "znapzend (PID=$$) Creating workers for the backup plans processing...\n";
+    print STDERR "znapzend (PID=$$) Creating workers for the backup plans processing...\n" if $self->debug;
     $self->$createWorkers;
 
     $self->zLog->info("znapzend (PID=$$) initialized -- resuming normal operations.");
@@ -1306,7 +1306,7 @@ sub start {
     #start eventloop
     Mojo::IOLoop->start;
 
-    print STDERR "znapzend (PID=$$) is done.\n";
+    print STDERR "znapzend (PID=$$) is done.\n" if $self->debug;
     return 1;
 }
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -1223,6 +1223,7 @@ my $daemonize = sub {
 
 ### RM_COMM_4_TEST ###  # remove ### RM_COMM_4_TEST ### comments for testing purpose.
 ### RM_COMM_4_TEST ###  print STDERR "fork: znapzend ($$) returning not exiting from parent process during test.\n";
+### RM_COMM_4_TEST ###  eval { if (defined(\@main::test_arr_children)) { print STDERR "PUSH!\n" ; push (@main::test_arr_children, $pid); }; };
 ### RM_COMM_4_TEST ###  return 254;
 
         #print STDERR "fork: znapzend ($$) exiting from parent process.\n";

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -1242,9 +1242,13 @@ my $daemonize = sub {
             }
         }
         setsid or die "Can't start a new session: $!";
-        open STDOUT, '>/dev/null' or die "ERROR: Redirecting STDOUT to /dev/null: $!";
+
         open STDIN, '</dev/null' or die "ERROR: Redirecting STDIN from /dev/null: $!";
+### RM_COMM_4_TEST ###  # remove ### RM_COMM_4_TEST ### comments for testing purpose.
+### RM_COMM_4_TEST ###  if (0) {
+        open STDOUT, '>/dev/null' or die "ERROR: Redirecting STDOUT to /dev/null: $!";
         open STDERR, '>/dev/null' or die "ERROR: Redirecting STDERR to /dev/null: $!";
+### RM_COMM_4_TEST ###  }
 
         # send warnings and die messages to log
         $SIG{__WARN__} = sub { $self->zLog->warn(shift) };

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -1283,8 +1283,10 @@ sub start {
         $self->$createWorkers;
     };
 
+    print STDERR "znapzend (PID=$$) Refreshing backup plans...\n";
     $self->$refreshBackupPlans($self->recursive, $self->inherited, $self->dataset);
 
+    print STDERR "znapzend (PID=$$) Creating workers for the backup plans processing...\n";
     $self->$createWorkers;
 
     $self->zLog->info("znapzend (PID=$$) initialized -- resuming normal operations.");
@@ -1299,6 +1301,7 @@ sub start {
     #start eventloop
     Mojo::IOLoop->start;
 
+    print STDERR "znapzend (PID=$$) is done.\n";
     return 1;
 }
 

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -12,7 +12,7 @@ use Data::Dumper;
 ### For "usual" datasets (filesystem,volume) `zfs` returns the
 ### properties inherited from higher level datasets; but for
 ### snapshots it only returns the same - not from higher snaps.
-my %inheritLevels = (
+our %inheritLevels = (
     local_only => 0,
     local_zfsinherit => 1,
     local_recurseparent => 2,

--- a/t/znapzend-daemonize.t
+++ b/t/znapzend-daemonize.t
@@ -84,7 +84,6 @@ sub runCommand_canThrow {
 }
 
 ### use threads;
-use Test::Builder;
 use Test::More;
 use Test::Exception;
 use Test::SharedFork; ### NOTE: Conflicts with ithreads

--- a/t/znapzend-daemonize.t
+++ b/t/znapzend-daemonize.t
@@ -32,7 +32,7 @@ unshift @INC, sub {
         $module_text =~ s/(.*?package\s+\S+)(.*)__END__/$1sub classWrapper {$2} classWrapper();/s;
 
         # uncomment testing code
-        $module_text =~ s/### RM_COMM_4_TEST ###//sg;
+        $module_text =~ s/### RM_COMM_4_TEST(|_main) ###//sg;
 
         # unhide private methods to avoid "Variable will not stay shared"
         # warnings that appear due to change of applicable scoping rules
@@ -76,7 +76,7 @@ sub runCommand {
 sub runCommand_canThrow {
     @ARGV = @_;
 
-    main();
+    return main();
 }
 
 ### use threads;

--- a/test.sh
+++ b/test.sh
@@ -4,6 +4,9 @@ PERL_CPANM_HOME="`pwd`/thirdparty" \
 PERL_CPANM_OPT='--notest --local-lib '"`pwd`/thirdparty" \
 perl ./thirdparty/bin/cpanm Devel::Cover::Report::Coveralls
 
+# Fail on a test line that dies so we can notice it
+set -e
+
 perl -I./thirdparty/lib/perl5 \
   -MDevel::Cover=+ignore,thirdparty ./t/znapzend.t ./bin/znapzend || test $? == 1
 perl -I./thirdparty/lib/perl5 \


### PR DESCRIPTION
Follows up from #501 and #502 to complete the issues found with #500 : `make check` now passes and the daemonized behaviors (e.g. clash over a pidfile) are now inspected in parent and child forks.