### PR TITLE
Convert inheritLevels into a class/struct, address issue #516

### DIFF
--- a/.github/workflows/spelling/whitelist.txt
+++ b/.github/workflows/spelling/whitelist.txt
@@ -320,6 +320,7 @@ myprint
 mysql
 NAL
 namespace
+namespaced
 nano
 newcfgdata
 newestbe
@@ -435,6 +436,7 @@ sourced
 sourceforge
 sourcemissing
 sourcetype
+sourcing
 SPAMALOT
 src
 srcame

--- a/.github/workflows/spelling/whitelist.txt
+++ b/.github/workflows/spelling/whitelist.txt
@@ -191,6 +191,7 @@ Getopt
 github
 gitignore
 gitlab
+gmail
 gmake
 gmtime
 gmx
@@ -263,6 +264,7 @@ Ivalue
 Iznapzendzetup
 JB
 JBERGER
+jimklimov
 JSON
 killproc
 Klimov

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -881,7 +881,7 @@ my $sendRecvCleanup = sub {
             for my $dst (sort grep { /^dst_[^_]+$/ } keys %$backupSet){
                 my $dstDataSet = $srcDataSet;
                 $dstDataSet =~ s/^\Q$backupSet->{src}\E/$backupSet->{$dst}/;
-                my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($srcDataSet, $dstDataSet, $dst, $backupSet->{snapCleanFilter}, undef);
+                my $recentCommon = $self->zZfs->mostRecentCommonSnapshot($srcDataSet, $dstDataSet, $dst, $backupSet->{snapCleanFilter}, undef, undef);
                 if ($recentCommon) {
                     $self->zLog->debug('not cleaning up source ' . $recentCommon . ' because it is needed by ' . $dstDataSet) if $self->debug;
                     #print STDERR "SOURCE CHILD CLEAN: BEFORE: " . Dumper($toDestroy) if $self->debug;

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -811,7 +811,12 @@ my $sendRecvCleanup = sub {
                         # and at least one destination is indeed offline,
                         # but it is not safe in current situation regarding
                         # last known sync points...
-                        $self->zLog->warn('ERROR: suspending recursive cleanup of source ' . $backupSet->{src} . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
+                        # Note this includes a case where source dataset has
+                        # NO snapshots (message is misleading but true then).
+                        # This should not happen in normal runs since znapzend
+                        # would create something, but can happen in --noaction
+                        # experiments for example.
+                        $self->zLog->warn('ERROR: suspending recursive cleanup of source ' . $backupSet->{src} . ' because a send task failed and no common snapshot was found for at least destination ' . $dstDataSet);
                         $doClean = 0;
                     }
                 }
@@ -892,7 +897,12 @@ my $sendRecvCleanup = sub {
                     # and at least one destination is indeed offline,
                     # but it is not safe in current situation regarding
                     # last known sync points...
-                    $self->zLog->warn('ERROR: suspending cleanup of source ' . $srcDataSet . ' because a send task failed and no common snapshot was found for at least ' . $dstDataSet);
+                    # Note this includes a case where source dataset has
+                    # NO snapshots (message is misleading but true then).
+                    # This should not happen in normal runs since znapzend
+                    # would create something, but can happen in --noaction
+                    # experiments for example.
+                    $self->zLog->warn('ERROR: suspending cleanup of source ' . $srcDataSet . ' because a send task failed and no common snapshot was found for at least destination ' . $dstDataSet);
                     next SRC_SET;
                 }
             }

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -1288,7 +1288,7 @@ sub getSnapshotProperties {
 
     if ($self->debug) {
         if ($numProps > 0) {
-            $self->zLog->debug("=== getSnapshotProperties(): GOT $inhMode (".Dumper($inherit).") properties of $snapshot : " .Dumper(\%properties) );
+            $self->zLog->debug("=== getSnapshotProperties(): GOT '$inhMode' properties of $snapshot : " .Dumper(\%properties) );
         }
     }
 
@@ -1355,7 +1355,7 @@ sub getSnapshotProperties {
                 #}
             }
         }
-        if ($inherit->zfs_local) {
+        if (!$inherit->snapshot_recurse_parent) {
             $self->zLog->debug("=== getSnapshotProperties(): Stopping recursion after $snapshot, we have all the properties we needed") if $self->debug;
         }
     }
@@ -1377,7 +1377,10 @@ sub getSnapshotProperties {
 
                 my $numParentProps = keys %$parentProperties;
                 if ($numParentProps > 0) {
-                    # Merge hash arrays, use existing values as overrides in case of conflict:
+                    # Merge hash arrays, use existing values as overrides in
+                    # case of same-name conflict; note that currently a prop
+                    # zfs-inherited from backupSet can win (was seen earlier)
+                    # over another prop set in a "nearer" parent dataset snapshot:
                     $self->zLog->debug("=== getSnapshotProperties(): Merging two property lists from '$parentSnapshot' and '$snapshot' :\n" .
                         "\t" . Dumper(\%$parentProperties) .
                         "\t" . Dumper(\%properties)

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -476,6 +476,9 @@ sub mostRecentCommonSnapshot {
     # getSnapshotProperties() code and struct inheritLevels.
     my $inherit = shift; # May be not passed => undef
     if (!defined($inherit)) {
+        # We leave defined but invalid values of $inherit to
+        # getSnapshotProperties() to figure out and complain,
+        # but for this routine's purposes set a specific default.
         $inherit = new inheritLevels;
         $inherit->zfs_local(1);
         $inherit->zfs_inherit(1);
@@ -1262,7 +1265,10 @@ sub getSnapshotProperties {
     my %properties;
     my $propertyPrefix = $self->propertyPrefix;
 
-    my @cmd = (@{$self->priv}, qw(zfs get -H -s), $inhMode);
+    my @cmd = (@{$self->priv}, qw(zfs get -H));
+    if ($inhMode ne '') {
+        push (@cmd, qw(-s), $inhMode);
+    }
     if ($self->zfsGetType) {
         push (@cmd, qw(-t snapshot));
     }

--- a/lib/inheritLevels.pm
+++ b/lib/inheritLevels.pm
@@ -104,3 +104,72 @@ __END__
 
 inheritLevels - helper struct for various options of ZFS property inheritance
 
+=head1 SYNOPSIS
+
+use inheritLevels;
+use ZnapZend::ZFS;
+...
+my $inherit = new inheritLevels;
+$inherit->zfs_local(1);
+$inherit->zfs_inherit(1);
+my $properties = $self->getSnapshotProperties($snapshot, $recurse, $inherit, @dstSyncedProps);
+...
+
+=head1 DESCRIPTION
+
+this object makes zfs property request inheritance settings easier to use
+
+currently used by ZnapZend::ZFS routines getSnapshotProperties and
+mostRecentCommonSnapshot but not really useful for getDataSetProperties
+so not yet utilized there
+
+=head1 ATTRIBUTES
+
+=head2 zfs_local
+
+ask for values defined locally in a dataset or snapshot itself
+
+=head2 zfs_inherit
+
+ask for values defined in parents of dataset or snapshot itself
+as reported by "zfs get" command on the current system; this may
+not include values defined in snapshots of a parent dataset's that
+are named same as the snapshot you are requesting properties of
+
+=head2 zfs_received
+
+ask for values defined by receiving a dataset or snapshot
+by "zfs send|zfs recv"
+
+(zfs_received is not currently used by znapzend but may have
+some meaning in the future)
+
+=head2 snapshot_recurse_parent
+
+meaningful only for requests of properties of snapshots: recursively
+ask for values defined locally in a same-named snapshot of a parent
+or a further ancestor dataset
+
+=head1 COPYRIGHT
+
+Copyright (c) 2020 by OETIKER+PARTNER AG. All rights reserved.
+
+=head1 LICENSE
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the Free
+Software Foundation, either version 3 of the License, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+more details.
+
+You should have received a copy of the GNU General Public License along with
+this program. If not, see L<http://www.gnu.org/licenses/>.
+
+=head1 AUTHOR
+
+S<Jim Klimov E<lt>jimklimov@gmail.comE<gt>>,
+S<Tobias Oetiker E<lt>tobi@oetiker.chE<gt>>

--- a/lib/inheritLevels.pm
+++ b/lib/inheritLevels.pm
@@ -1,0 +1,106 @@
+package inheritLevels;
+# Note: classes made by Class::Struct may not be sub-namespaced
+
+use Class::Struct;
+
+### Property inheritance levels - how deep we go in routines
+### that (need to) care about these nuances beyond a boolean.
+### Primarily intended for getSnapshotProperties() to get props
+### defined by snapshots of parent datasets with same snapnames.
+### For "usual" datasets (filesystem,volume) `zfs` returns the
+### properties inherited from higher level datasets; but for
+### snapshots it only returns the same - not from higher snaps.
+struct ('inheritLevels' => {
+    zfs_local => '$', # set to ask for properties defined locally in dataset
+    zfs_inherit => '$', # set to ask for properties inherited from higher datasets
+    zfs_received => '$', # set to ask for properties received during "zfs send|recv" (no-op for now, mentioned for completeness)
+    snapshot_recurse_parent => '$' # "manually" (not via zfs tools) look in same-named snapshots of parent datasets
+    } ) ;
+
+    # NOTE that some versions of zfs do not inherit values from same-named
+    # snapshot of a parent dataset, but only from a "real" dataset higher
+    # in the data hierarchy, so the "-s inherit" argument may be effectively
+    # ignored by OS for the purposes of *such* inheritance. Reasonable modes
+    # of sourcing properties include:
+    #   0 = only local
+    #   1 = local + inherit as defined by zfs
+    #   2 = local + recurse into parent that has same snapname
+    #   3 = local + inherit as defined by zfs + recurse into parent
+    # In older code other name-code mappings included:
+    #    local_only => 0,
+    #    local_zfsinherit => 1,
+    #    local_recurseparent => 2,
+    #    local_recurseparent_zfsinherit => 3,
+
+sub getInhMode {
+    # Method to return a string for "zfs get -s ..." based on the flags in class instance
+    my $self = shift;
+    my $inhMode = '';
+    if ($self->zfs_local) {
+        $inhMode .= 'local';
+    }
+    if ($self->zfs_inherit) {
+        if ($inhMode eq '') {
+            $inhMode = 'inherited';
+        } else {
+            $inhMode .= ',inherited';
+        }
+    }
+    if ($self->zfs_received) {
+        if ($inhMode eq '') {
+            $inhMode = 'received';
+        } else {
+            $inhMode .= ',received';
+        }
+    }
+    return $inhMode;
+}
+
+sub reset {
+    # Without args, just resets all fields back to undef so they can be
+    # re-assigned later. With an arg tries to import a legacy setting by
+    # number or string, or copy from another instance of inheritLevels.
+    my $self = shift;
+    
+    $self->zfs_local(undef);
+    $self->zfs_inherit(undef);
+    $self->zfs_received(undef);
+    $self->snapshot_recurse_parent(undef);
+    if (@_) {
+        my $arg = shift;
+        # Assign from legacy values
+        if ($arg->isa('inheritLevels')) {
+            $self->zfs_local($arg->zfs_local);
+            $self->zfs_inherit($arg->zfs_inherit);
+            $self->zfs_received($arg->zfs_received);
+            $self->snapshot_recurse_parent($arg->snapshot_recurse_parent);
+        } elsif ($arg == 0 or $arg eq 'local_only' or $arg eq 'zfs_local') {
+            $self->zfs_local(1);
+        } elsif ($arg == 1 or $arg eq 'local_zfsinherit') {
+            $self->zfs_local(1);
+            $self->zfs_inherit(1);
+        } elsif ($arg == 2 or $arg eq 'local_recurseparent') {
+            $self->zfs_local(1);
+            $self->snapshot_recurse_parent(1);
+        } elsif ($arg == 3 or $arg eq 'local_recurseparent_zfsinherit') {
+            $self->zfs_local(1);
+            $self->snapshot_recurse_parent(1);
+            $self->zfs_inherit(1);
+        } elsif (!defined($arg) or $arg == undef) {
+            1; # No-op, keep fields undef
+        } else {
+            warn "inheritLevels::reset() got unsupported argument '$arg'\n";
+            return 0;
+        }
+    }
+    return 1;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+inheritLevels - helper struct for various options of ZFS property inheritance
+


### PR DESCRIPTION
This completes the move from magic numbers for modes of inheritance (that was a simple way to PoC the idea ;) ) through an enum-like naming of magic numbers to an `inheritLevels` class that carries flags for wanted activities and some helper routines to convert key values and generate argument strings for `zfs get`.

This also changes the way these hints are used (and modified) during `getSnapshotProperties()` processing, and sets a lowest precedence for "inherited" values (coming from "real" datasets in ZFS versions I have under hands) to tag after values defined in snapshot properties.