### PR TITLE
Optionally email the admin if a send task failed and we suspend the source cleanup

### DIFF
--- a/.github/workflows/spelling/whitelist.txt
+++ b/.github/workflows/spelling/whitelist.txt
@@ -158,6 +158,7 @@ endif
 ENTRYPOINT
 envval
 envvar
+errline
 errmsg
 esac
 esyscmd
@@ -208,6 +209,7 @@ HMSz
 Honame
 html
 http
+hostname
 Hypnotoad
 Icommand
 Icommon
@@ -289,6 +291,7 @@ lowmem
 lpr
 lsb
 ltrim
+mailprog
 MAINPID
 makeinfo
 manpage
@@ -418,6 +421,7 @@ scriptversion
 SEENSRC
 SEENDST
 selftest
+sendmail
 setsid
 shellwords
 shtml

--- a/.github/workflows/spelling/whitelist.txt
+++ b/.github/workflows/spelling/whitelist.txt
@@ -351,6 +351,7 @@ oep
 oetiker
 oi
 ojo
+opencsw
 openindiana
 openlog
 openssh
@@ -554,6 +555,7 @@ withval
 WNOHANG
 WORKDIR
 workflow
+Wperl
 wu
 www
 wx

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ have to build some dependency modules. The GNU make is needed instead of Sun
 make due to syntax differences.
 Alternately, take a look at
 [CSW packaging of perl-5.10.1 or newer](https://www.opencsw.org/packages/CSWperl/)
-and its modules, and other dependencies. If you use that implementation,
-you would need to change the shebangs in `znapzend`, `znapzendzetup` and
-`znapzendztatz` scripts to reference it instead of system perl, like this:
+and its modules, and other dependencies. To use a non-default perl, set the PERL environment variable to the path of your favorite perl interpreter prior to running `configure`. Eg. `PERL=/opt/perl-32/bin/perl5.32.1 ./configure`
 
 * On OmniOS/SmartOS you will need perl and gnu-make packages.
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,6 @@ Alternately, take a look at
 and its modules, and other dependencies. If you use that implementation,
 you would need to change the shebangs in `znapzend`, `znapzendzetup` and
 `znapzendztatz` scripts to reference it instead of system perl, like this:
-```sh
-#!/opt/csw/bin/perl
-###!/usr/bin/env perl
-```
 
 * On OmniOS/SmartOS you will need perl and gnu-make packages.
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,19 @@ To also bootstrap on Ubuntu / Debian you may need:
 apt-get install autoconf carton
 ```
 
-* On Solaris you may need the C compiler from Solaris Studio and gnu-make
-since the installed perl version is probably very old.
+* On Solaris 10 you may need the C compiler from Solaris Studio and gnu-make
+since the installed perl version is probably very old and you would likely
+have to build some dependency modules. The GNU make is needed instead of Sun
+make due to syntax differences.
+Alternately, take a look at
+[CSW packaging of perl-5.10.1 or newer](https://www.opencsw.org/packages/CSWperl/)
+and its modules, and other dependencies. If you use that implementation,
+you would need to change the shebangs in `znapzend`, `znapzendzetup` and
+`znapzendztatz` scripts to reference it instead of system perl, like this:
+```sh
+#!/opt/csw/bin/perl
+###!/usr/bin/env perl
+```
 
 * On OmniOS/SmartOS you will need perl and gnu-make packages.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ apt-get install autoconf carton
 * On Solaris 10 you may need the C compiler from Solaris Studio and gnu-make
 since the installed perl version is probably very old and you would likely
 have to build some dependency modules. The GNU make is needed instead of Sun
-make due to syntax differences.
+make due to syntax differences. Notably you should reference it if you would
+boot-strap the code workspace from scratch:
+```sh
+MAKE=gmake ./bootstrap.sh
+```
 Alternately, take a look at
 [CSW packaging of perl-5.10.1 or newer](https://www.opencsw.org/packages/CSWperl/)
 and its modules, and other dependencies. To use a non-default perl, set the

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ have to build some dependency modules. The GNU make is needed instead of Sun
 make due to syntax differences.
 Alternately, take a look at
 [CSW packaging of perl-5.10.1 or newer](https://www.opencsw.org/packages/CSWperl/)
-and its modules, and other dependencies. To use a non-default perl, set the PERL environment variable to the path of your favorite perl interpreter prior to running `configure`. Eg. `PERL=/opt/perl-32/bin/perl5.32.1 ./configure`
+and its modules, and other dependencies. To use a non-default perl, set the
+`PERL` environment variable to the path of your favorite perl interpreter
+prior to running `configure`, e.g.:
+```sh
+PERL=/opt/perl-32/bin/perl5.32.1 ./configure
+```
 
 * On OmniOS/SmartOS you will need perl and gnu-make packages.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ boot-strap the code workspace from scratch:
 ```sh
 MAKE=gmake ./bootstrap.sh
 ```
-Alternately, take a look at
+Note also that the perl version 5.8.4 provided with Solaris 10 is too old for
+the syntax and dependencies of znapzend. As one alternative, take a look at
 [CSW packaging of perl-5.10.1 or newer](https://www.opencsw.org/packages/CSWperl/)
 and its modules, and other dependencies. To use a non-default perl, set the
 `PERL` environment variable to the path of your favorite perl interpreter

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -613,9 +613,14 @@ code or is killed by a signal.
 
 =item B<--cleanOffline>
 
-Clean snapshots of a source dataset even if one or more destination datasets failed during replication.
-The most recent common snapshot for each destination will not be deleted, but this is a
-potentially dangerous option. If the preserved snapshot somehow gets deleted from the
+Clean snapshots of a source dataset even if one or more destination datasets
+failed during replication for whatever reason (destination offline, destination
+full, destination pool became read-only due to storage issues, source too full
+to make a snapshot, etc.).
+
+The most recent common snapshot for each destination (as tracked on source for
+resilience) will not be deleted from source, but this is still a potentially
+dangerous option: if the preserved snapshot somehow gets deleted from the
 destination, it may require a full re-replication the next time it is online.
 
 =back

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -22,7 +22,7 @@ sub main {
             # for "zfs send", so the longer variants --skipIntermediates
             # vs. --sendIntermediates are not documented in the manpage.
         qw(skipOnPreSnapCmdFail skipOnPreSendCmdFail recursive|r inherited since=s sinceForced=s),
-        qw(cleanOffline)
+        qw(cleanOffline mailErrorSummaryTo=s)
         ) or exit 1;
 
     $opts->{version} && do {
@@ -204,6 +204,7 @@ B<znapzend> [I<options>...]
  --skipOnPreSnapCmdFail skip snapshots if the pre-snap-command fails
  --skipOnPreSendCmdFail skip replication if the pre-send-command fails
  --cleanOffline         clean up source snapshots even if a destination was offline
+ --mailErrorSummaryTo=rcpt  if "send task(s) failed", mail a summary to rcpt
 
 =head1 DESCRIPTION
 
@@ -622,6 +623,15 @@ The most recent common snapshot for each destination (as tracked on source for
 resilience) will not be deleted from source, but this is still a potentially
 dangerous option: if the preserved snapshot somehow gets deleted from the
 destination, it may require a full re-replication the next time it is online.
+
+=item B<--mailErrorSummaryTo=rcpt(@domain),...>
+
+If this argument is passed, a copy of error summary would be sent there by
+your system's command line mailer program. It is then up to this program and
+system setup to validate the recipient names (local or domain-suffixed) and
+deliver the message to some mailbox.
+
+This feature relies on a program which supports standard sendmail-like CLI.
 
 =back
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-autoreconf --force --install --verbose --make
-if test -d .git; then
+autoreconf --force --install --verbose --make || exit
+if (which git 2>/dev/null >/dev/null) && test -d .git; then
   git log --full-history --simplify-merges --dense --no-merges > CHANGES
 fi
 # EOF

--- a/doc/znapzend.pod
+++ b/doc/znapzend.pod
@@ -41,6 +41,7 @@ B<znapzend> [I<options>...]
  --skipOnPreSnapCmdFail skip snapshots if the pre-snap-command fails
  --skipOnPreSendCmdFail skip replication if the pre-send-command fails
  --cleanOffline         clean up source snapshots even if a destination was offline
+ --mailErrorSummaryTo=rcpt  if "send task(s) failed", mail a summary to rcpt
 
 =head1 DESCRIPTION
 
@@ -450,10 +451,24 @@ code or is killed by a signal.
 
 =item B<--cleanOffline>
 
-Clean snapshots of a source dataset even if one or more destination datasets failed during replication.
-The most recent common snapshot for each destination will not be deleted, but this is a
-potentially dangerous option. If the preserved snapshot somehow gets deleted from the
+Clean snapshots of a source dataset even if one or more destination datasets
+failed during replication for whatever reason (destination offline, destination
+full, destination pool became read-only due to storage issues, source too full
+to make a snapshot, etc.).
+
+The most recent common snapshot for each destination (as tracked on source for
+resilience) will not be deleted from source, but this is still a potentially
+dangerous option: if the preserved snapshot somehow gets deleted from the
 destination, it may require a full re-replication the next time it is online.
+
+=item B<--mailErrorSummaryTo=rcpt(@domain),...>
+
+If this argument is passed, a copy of error summary would be sent there by
+your system's command line mailer program. It is then up to this program and
+system setup to validate the recipient names (local or domain-suffixed) and
+deliver the message to some mailbox.
+
+This feature relies on a program which supports standard sendmail-like CLI.
 
 =back
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -53,7 +53,7 @@ has nodelay                 => sub { 0 };
 has skipOnPreSnapCmdFail    => sub { 0 };
 has skipOnPreSendCmdFail    => sub { 0 };
 has cleanOffline            => sub { 0 };
-has mailErrorSummaryTo      => sub { q{} };
+has 'mailErrorSummaryTo';
 has backupSets              => sub { [] };
 
 has zConfig => sub {

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -769,7 +769,7 @@ my $sendRecvCleanup = sub {
                 scalar(@sendFailed) . ' send task(s) failed:' ;
         }
         $self->zLog->warn($errline);
-        if ($self->mailErrorSummaryTo ne '') {
+        if ($self->mailErrorSummaryTo) {
             $errmsg = $errline . "\n";
         }
         for $errline (@sendFailed) {

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -779,7 +779,7 @@ my $sendRecvCleanup = sub {
             }
         }
 
-        if ($self->mailErrorSummaryTo ne '') {
+        if ($self->mailErrorSummaryTo) {
             #my $mailprog = '/usr/lib/sendmail';
             my $mailprog = '/usr/sbin/sendmail';
             #my $from_address = "`id`@`hostname`" ;

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -53,6 +53,7 @@ has nodelay                 => sub { 0 };
 has skipOnPreSnapCmdFail    => sub { 0 };
 has skipOnPreSendCmdFail    => sub { 0 };
 has cleanOffline            => sub { 0 };
+has mailErrorSummaryTo      => sub { q{} };
 has backupSets              => sub { [] };
 
 has zConfig => sub {
@@ -755,18 +756,46 @@ my $sendRecvCleanup = sub {
     #we want the message summarizing errors regardless of continuing to cleanup
     if (scalar(@sendFailed) > 0) {
         my $errmsg;
+        my $errline;
         if ($self->cleanOffline) {
             # Note: this is about all transfer failures, such as offline dest
             # or it is full, or read-only, or source too full to make a snap...
-            $errmsg = 'ERROR: ' . scalar(@sendFailed) . ' send task(s) below failed,' .
-                ' but "cleanOffline" mode is on so proceeding to cleanup source dataset carefully:' ;
+            $errline = 'ERROR: ' . scalar(@sendFailed) . ' send task(s) below ' .
+                'failed for ' . $backupSet->{src} . ', but "cleanOffline" mode ' .
+                'is on, so proceeding to clean up source dataset carefully:' ;
         } else {
-            $errmsg = 'ERROR: suspending cleanup source dataset because ' .
+            $errline = 'ERROR: suspending cleanup source dataset ' .
+                $backupSet->{src} . ' because ' .
                 scalar(@sendFailed) . ' send task(s) failed:' ;
         }
-        $self->zLog->warn($errmsg);
-        for $errmsg (@sendFailed) {
-            $self->zLog->warn(' +-->   ' . $errmsg);
+        $self->zLog->warn($errline);
+        if ($self->mailErrorSummaryTo ne '') {
+            $errmsg = $errline . "\n";
+        }
+        for $errline (@sendFailed) {
+            $self->zLog->warn(' +-->   ' . $errline);
+            if ($self->mailErrorSummaryTo ne '') {
+                $errmsg .= ' +-->   ' . $errline . "\n";
+            }
+        }
+
+        if ($self->mailErrorSummaryTo ne '') {
+            #my $mailprog = '/usr/lib/sendmail';
+            my $mailprog = '/usr/sbin/sendmail';
+            #my $from_address = "`id`@`hostname`" ;
+            if (open (MAIL, "|$mailprog -t " . $self->mailErrorSummaryTo)) {
+                $self->zLog->warn('Sending a copy of the report above to ' . $self->mailErrorSummaryTo);
+                print MAIL "To: " . $self->mailErrorSummaryTo . "\n";
+                #print MAIL "From: " . $from_address . "\n";
+                print MAIL "Subject: znapzend replication error summary\n";
+                print MAIL "-------\n";
+                print MAIL $errmsg;
+                print MAIL "-------\n";
+                print MAIL ".\n";
+                close(MAIL);
+            } else {
+                warn "Can't open $mailprog to send a copy of the report above to " . $self->mailErrorSummaryTo . "!\n";
+            }
         }
     }
 

--- a/man/znapzend.1
+++ b/man/znapzend.1
@@ -176,6 +176,7 @@ znapzend \- znapzend daemon
 \& \-\-skipOnPreSnapCmdFail skip snapshots if the pre\-snap\-command fails
 \& \-\-skipOnPreSendCmdFail skip replication if the pre\-send\-command fails
 \& \-\-cleanOffline         clean up source snapshots even if a destination was offline
+\& \-\-mailErrorSummaryTo=rcpt  if "send task(s) failed", mail a summary to rcpt
 .Ve
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
@@ -566,10 +567,23 @@ it has a \fBpre-snap-command\fR defined and the command returns a non-zero exit
 code or is killed by a signal.
 .IP "\fB\-\-cleanOffline\fR" 4
 .IX Item "--cleanOffline"
-Clean snapshots of a source dataset even if one or more destination datasets failed during replication.
-The most recent common snapshot for each destination will not be deleted, but this is a
-potentially dangerous option. If the preserved snapshot somehow gets deleted from the
+Clean snapshots of a source dataset even if one or more destination datasets
+failed during replication for whatever reason (destination offline, destination
+full, destination pool became read-only due to storage issues, source too full
+to make a snapshot, etc.).
+.Sp
+The most recent common snapshot for each destination (as tracked on source for
+resilience) will not be deleted from source, but this is still a potentially
+dangerous option: if the preserved snapshot somehow gets deleted from the
 destination, it may require a full re-replication the next time it is online.
+.IP "\fB\-\-mailErrorSummaryTo=rcpt(@domain),...\fR" 4
+.IX Item "--mailErrorSummaryTo=rcpt(@domain),..."
+If this argument is passed, a copy of error summary would be sent there by
+your system's command line mailer program. It is then up to this program and
+system setup to validate the recipient names (local or domain-suffixed) and
+deliver the message to some mailbox.
+.Sp
+This feature relies on a program which supports standard sendmail-like \s-1CLI.\s0
 .SH "EXAMPLE"
 .IX Header "EXAMPLE"
 To test a new config:


### PR DESCRIPTION
Should send the error summary to specified recipient(s) and fix the issue #499 as far as I (original poster) am concerned :) 

Tested on a local system, delivers to one or two (comma-separated) local mailboxes using the standard `/usr/lib/sendmail` or `/usr/sbin/sendmail` alias (exim, postfix also provide that interface). Internet delivery is up to MTA setup and outside znapzend's interest.

````
:; znapzend --noaction --runonce=nvpool/SHARED/var/test --inherited --debug --cleanOffline --mailErrorSummaryTo=root,jim

...
[2020-08-20 00:29:08.80293] [26384] [warn] ERROR: 1 send task(s) below failed for nvpool/SHARED/var/test, but "cleanOffline" mode is on, so proceeding to clean up source dataset carefully:
[2020-08-20 00:29:08.80315] [26384] [warn]  +-->   destination 'backup-adata/snapshots/nvpool/SHARED/var/test' does not exist or is offline. ignoring it for this round...
[2020-08-20 00:29:08.80643] [26384] [warn] Sending a copy of the report above to root,jim
[2020-08-20 00:29:08.83905] [26384] [debug] checking to clean up snapshots recursively from source nvpool/SHARED/var/test
...
````

If the mail program does not exist in standard path (currently hardcoded, can be made an argument later), it is noted but not fatal:
````
[2020-08-20 00:27:28.54081] [26359] [warn] ERROR: 1 send task(s) below failed for nvpool/SHARED/var/test, but "cleanOffline" mode is on, so proceeding to clean up source dataset carefully:
[2020-08-20 00:27:28.54089] [26359] [warn]  +-->   destination 'backup-adata/snapshots/nvpool/SHARED/var/test' does not exist or is offline. ignoring it for this round...
Can't exec "/usr/sbin/sendmailsss": No such file or directory at /export/home/jim/shared/znapzend/bin/../lib/ZnapZend.pm line 786.
Can't open /usr/sbin/sendmailsss to send a copy of the report above to root,jim!
````

Message in the box:
````
From jim@jimoi.local Thu Aug 20 00:29:08 2020
Return-Path: <jim@jimoi.local>
Received: from jimoi.local (jimoi [127.0.0.1])
        by jimoi.local (8.15.2+Sun/8.15.2) with ESMTP id 07JMT880026388;
        Thu, 20 Aug 2020 00:29:08 +0200 (CEST)
Received: (from jim@localhost)
        by jimoi.local (8.15.2+Sun/8.15.2/Submit) id 07JMT8wN026387;
        Thu, 20 Aug 2020 00:29:08 +0200 (CEST)
Date: Thu, 20 Aug 2020 00:29:08 +0200 (CEST)
From: jim <jim@jimoi.local>
Message-Id: <202008192229.07JMT8wN026387@jimoi.local>
To: root@jimoi.local, jim@jimoi.local
Subject: znapzend replication error summary
Content-Length: 290

-------
ERROR: 1 send task(s) below failed for nvpool/SHARED/var/test, but "cleanOffline" mode is on, so proceeding to clean up source dataset carefully:
 +-->   destination 'backup-adata/snapshots/nvpool/SHARED/var/test' does not exist or is offline. ignoring it for this round...
-------
````