### PR TITLE
ZFS.pm : getSnapshotProperties()/getDataSetProperties() : recursive mode…

### DIFF
--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -910,6 +910,9 @@ sub getDataSetProperties {
         my %properties;
         # TODO : support "inherit-from-local" mode
         my @cmd = (@{$self->priv}, qw(zfs get -H));
+        if ($recurse) {
+            push (@cmd, qw(-r));
+        }
         if ($inherit) {
             push (@cmd, qw(-s), 'local,inherited');
         } else {
@@ -917,9 +920,6 @@ sub getDataSetProperties {
         }
         if ($self->zfsGetType) {
             push (@cmd, qw(-t), 'filesystem,volume');
-        }
-        if ($recurse) {
-            push (@cmd, qw(-r));
         }
         push (@cmd, qw(-o), 'name,property,value,source', 'all', $listElem);
         print STDERR '# ' . join(' ', @cmd) . "\n" if $self->debug;
@@ -1238,14 +1238,14 @@ sub getSnapshotProperties {
     my $propertyPrefix = $self->propertyPrefix;
 
     my @cmd = (@{$self->priv}, qw(zfs get -H));
+    if ($recurse) {
+        push (@cmd, qw(-r));
+    }
     if ($inhMode ne '') {
         push (@cmd, qw(-s), $inhMode);
     }
     if ($self->zfsGetType) {
         push (@cmd, qw(-t snapshot));
-    }
-    if ($recurse) {
-        push (@cmd, qw(-r));
     }
     push (@cmd, qw(-o), 'property,value,source', $propnames, $snapshot);
 


### PR DESCRIPTION
…when building "zfs get" @cmd, specify "-r" (if requested) earlier in command line

to avoid this:
````
$ zfs get -t filesystem -s local,received all -r nvpool/SHARED
===>>> cannot open '-r': dataset does not exist
NAME           PROPERTY                    VALUE                                                              SOURCE
nvpool/SHARED  mountpoint                  legacy                                                             received
nvpool/SHARED  compression                 gzip-9                                                             received
nvpool/SHARED  canmount                    off                                                                received
...
nvpool/SHARED  com.sun:auto-snapshot       false                                                              local
````

and no actual recursion :\

Checked that the bug happens, and resulting behavior after the CLI reshuffle differs (returns recursive data as expected) on both old Solaris 10 and recent OpenIndiana.