### PR TITLE
Problem: Hard to use znapzend dev bins in a web of symlinks

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 use lib qw(); # PERL5LIB
-use FindBin; use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../thirdparty/lib/perl5"; # LIBDIR
+use FindBin; use lib "$FindBin::RealBin/../lib", "$FindBin::RealBin/../thirdparty/lib/perl5"; # LIBDIR
 
 use Getopt::Long qw(:config posix_default no_ignore_case);
 use Pod::Usage;

--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 use lib qw(); # PERL5LIB
-use FindBin; use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../thirdparty/lib/perl5"; # LIBDIR
+use FindBin; use lib "$FindBin::RealBin/../lib", "$FindBin::RealBin/../thirdparty/lib/perl5"; # LIBDIR
 
 use Getopt::Long qw(:config posix_default no_ignore_case pass_through);
 use Pod::Usage;

--- a/bin/znapzendztatz
+++ b/bin/znapzendztatz
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 
 use lib qw(); # PERL5LIB
-use FindBin; use lib "$FindBin::Bin/../lib", "$FindBin::Bin/../thirdparty/lib/perl5"; # LIBDIR
+use FindBin; use lib "$FindBin::RealBin/../lib", "$FindBin::RealBin/../thirdparty/lib/perl5"; # LIBDIR
 
 use Getopt::Long qw(:config posix_default no_ignore_case);
 use Pod::Usage;


### PR DESCRIPTION
Solution: Follow up from 75857808ab5fc1030ac294c4e3634d4b5ef323c9
which added the line which is removed during "proper" installation,
but now use FindBin::RealBin instead of just ::Bin to allow developers
to shoot themselves in the foot easier by symlinking their version
in progress (or a snapshot of the development workspace) right into
their `/usr/bin/znapzend*` pathnames.

Signed-off-by: Jim Klimov <jimklimov@gmail.com>