### PR TITLE
Replace ForkCall with Subprocess, fix #494

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+ - removed depencency on ForkCall @fdd-rev
+ 
 0.21.1 2022-01-20 16:13:24 +0100 Tobias Oetiker <tobi@oetiker.ch>
 
  - fixed delay redefined warning

--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,4 @@
 requires 'Mojolicious' , '>= 8.73, <9.0';
-requires 'Mojo::IOLoop::ForkCall';
 requires 'Scalar::Util', '>= 1.45';
 requires 'Test::SharedFork';
 requires 'Test::Exception';

--- a/cpanfile.in
+++ b/cpanfile.in
@@ -1,5 +1,4 @@
 requires 'Mojolicious' @MOJOLICIOUS_VERSION_CONSTRAINT@;
-requires 'Mojo::IOLoop::ForkCall';
 requires 'Scalar::Util', '>= 1.45';
 requires 'Test::SharedFork';
 requires 'Test::Exception';


### PR DESCRIPTION
Hello, I was repackaging znapzend for Debian 11 and I noticed Mojo::IOLoop::ForkCall is deprecated and Debian ships no official package for it, so I did o couple of fixes to use Mojo::IOLoop::Subprocess instead.

Also this should allow you to loosen the Mojolicious version requirements (#571) both upward and downward.  I tested with Mojolicious 8.71 and it works just fine.

I didn't try to edit CPAN-related files as I'm not using them... I'm not a Perl programmer myself, but I hope this is a good starting point. :)