### PR TITLE
Fix regex in `splitHostDataSet` to understand dataset names with colons (e.g. OpenIndiana timestamped rootfs)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
  - removed depencency on ForkCall @fdd-rev
+ - Fix regex in splitHostDataSet to understand dataset names with colons  @jimklimov
  
 0.21.1 2022-01-20 16:13:24 +0100 Tobias Oetiker <tobi@oetiker.ch>
 

--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -543,6 +543,10 @@ and where 'command' and its unique options is one of the following:
             [ DST[:key] plan [[user@]host:]dataset
                 [pre-send-command] [post-send-command] ]
 
+            NOTE: If you specify [user@]host:dataset for remote replication
+            over SSH, make use of ~/.ssh/config for any advanced options
+            (custom ports, keys to use, etc.) See znapzend READNE for ideas.
+
     delete  [--dst=key] <src_dataset>
 
     edit    [--recursive=on|off] \

--- a/contrib/test-splitHostDataSet.sh
+++ b/contrib/test-splitHostDataSet.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Help test chosen regex for splitHostDataSet()
+# (C) 2022 by Jim Klimov
+
+# https://github.com/oetiker/znapzend/issues/585
+#RE='/^(?:(.+)\s)?([^\s]+)$/'
+RE='/^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/'
+
+echo 'NOTE: For each probe this should return an array with two strings:'
+echo '      empty "", "remotehost" or "user@remotehost" as applicable,'
+echo '      and the dataset(@snapshot) name'
+#    "root@host -p 22 -id /tmp/key rpool@snaptime-12:34:56" \
+for S in \
+    "rpool/zones/nut/jenkins-worker/ROOT/openindiana-20220315-backup-1" \
+    "rpool/zones/nut/jenkins-worker/ROOT/openindiana-20220315-backup-1@snap" \
+    "rpool/zones/nut/jenkins-worker/ROOT/openindiana-20220315-backup-1@snaptime-12:34:56" \
+    "rpool/zones/nut/jenkins-worker/ROOT/openindiana-2022:03:15-backup-1" \
+    "rpool/zones/nut/jenkins-worker/ROOT/openindiana-2022:03:15-backup-1@snap" \
+    "rpool/zones/nut/jenkins-worker/ROOT/openindiana-2022:03:15-backup-1@snaptime-12:34:56" \
+    "remotehost:pond/data/set" \
+    "remotehost:pond/data/set@snap" \
+    "remotehost:pond/data/set@snaptime-12:34:56" \
+    "remotehost:pond/data/set/openindiana-2022:03:15-backup-1" \
+    "remotehost:pond/data/set/openindiana-2022:03:15-backup-1@snap" \
+    "remotehost:pond/data/set/openindiana-2022:03:15-backup-1@snaptime-12:34:56" \
+    "user@remotehost:pond/data/set" \
+    "user@remotehost:pond/data/set@snap" \
+    "user@remotehost:pond/data/set@snaptime-12:34:56" \
+    "user@remotehost:pond/data/set/openindiana-2022:03:15-backup-1" \
+    "user@remotehost:pond/data/set/openindiana-2022:03:15-backup-1@snap" \
+    "user@remotehost:pond/data/set/openindiana-2022:03:15-backup-1@snaptime-12:34:56" \
+; do
+    perl -e 'print STDERR "[D] Split \"" . $ARGV[0] . "\" into:\n\t[\"" . join("\", \"", ($ARGV[0] =~ '"$RE"')) . "\"]\n";' "$S"
+done
+

--- a/contrib/test-splitHostDataSet.sh
+++ b/contrib/test-splitHostDataSet.sh
@@ -5,7 +5,8 @@
 
 # https://github.com/oetiker/znapzend/issues/585
 #RE='/^(?:(.+)\s)?([^\s]+)$/'
-RE='/^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/'
+#RE='/^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/'
+RE='/^(?:([^:\/]+):)?([^@\s]+|[^@\s]+\@[^@\s]+)$/'
 
 echo 'NOTE: For each probe this should return an array with two strings:'
 echo '      empty "", "remotehost" or "user@remotehost" as applicable,'

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -40,7 +40,13 @@ has priv            => sub { my $self = shift; [$self->rootExec ? split(/ /, $se
 my $splitHostDataSet = sub {
 #JIM#    return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
 #JIM#    See https://github.com/oetiker/znapzend/issues/585
-    return ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
+    #return ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
+
+    my @return;
+    #push @return, ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
+    push @return, ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
+    print STDERR "[D] Split '" . $_[0] . "' into: ['" . join("', '", @return) . "']\n";# if $self->debug;
+    return @return;
 };
 
 my $splitDataSetSnapshot = sub {

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -38,9 +38,11 @@ has priv            => sub { my $self = shift; [$self->rootExec ? split(/ /, $se
 
 ### private functions ###
 my $splitHostDataSet = sub {
-#JIM#    return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
-#JIM#    See https://github.com/oetiker/znapzend/issues/585
-    #return ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
+    # See also https://github.com/oetiker/znapzend/issues/585
+    # If there are further bugs in the regex, comment away the
+    # next implementation line and fall through to verbosely
+    # debugging code below to try and iterate a fix:
+    return ($_[0] =~ /^(?:([^:\/]+):)?([^@\s]+|[^@\s]+\@[^@\s]+)$/);
 
     my @return;
     ###push @return, ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -38,7 +38,9 @@ has priv            => sub { my $self = shift; [$self->rootExec ? split(/ /, $se
 
 ### private functions ###
 my $splitHostDataSet = sub {
-    return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
+#JIM#    return ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
+#JIM#    See https://github.com/oetiker/znapzend/issues/585
+    return ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
 };
 
 my $splitDataSetSnapshot = sub {

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -43,9 +43,12 @@ my $splitHostDataSet = sub {
     #return ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
 
     my @return;
-    #push @return, ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
-    push @return, ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
-    print STDERR "[D] Split '" . $_[0] . "' into: ['" . join("', '", @return) . "']\n";# if $self->debug;
+    ###push @return, ($_[0] =~ /^(?:(.+)\s)?([^\s]+)$/);
+    ###push @return, ($_[0] =~ /^(?:([^:\/]+):)?([^:]+|[^:@]+\@.+)$/);
+    push @return, ($_[0] =~ /^(?:([^:\/]+):)?([^@\s]+|[^@\s]+\@[^@\s]+)$/);
+    # Note: Claims `Use of uninitialized value $return[0]...` when there
+    # is no remote host portion matched, so using a map to stringify:
+    print STDERR "[D] Split '" . $_[0] . "' into: [" . join(", ", map { defined ? "'$_'" : '<undef>' } @return) . "]\n";# if $self->debug;
     return @return;
 };
 

--- a/man/znapzendzetup.1
+++ b/man/znapzendzetup.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "ZNAPZENDZETUP 1"
-.TH ZNAPZENDZETUP 1 "2022-01-20" "0.21.1" "znapzend"
+.TH ZNAPZENDZETUP 1 "2022-10-21" "0.21.1" "znapzend"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -165,6 +165,10 @@ and where 'command' and its unique options is one of the following:
 \&            SRC plan dataset \e
 \&            [ DST[:key] plan [[user@]host:]dataset
 \&                [pre\-send\-command] [post\-send\-command] ]
+\&
+\&            NOTE: If you specify [user@]host:dataset for remote replication
+\&            over SSH, make use of ~/.ssh/config for any advanced options
+\&            (custom ports, keys to use, etc.) See znapzend READNE for ideas.
 \&
 \&    delete  [\-\-dst=key] <src_dataset>
 \&


### PR DESCRIPTION
Closes: #585