### PR TITLE
Add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,16 @@
+# Windows script files should be CR+LF always:
+*.bat text eol=crlf
+
+# Unix/Linux script files should be LF always:
+*.sh text eol=lf
+*.m4 text eol=lf
+*.ac text eol=lf
+*.am text eol=lf
+
+# Some files are binary always:
+*.png bin
+*.ico bin
+
+# The rest are assumed text sources with platform-dependent EOL being okay,
+# or we let Git guess otherwise:
+* text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,12 @@
 *.m4 text eol=lf
 *.ac text eol=lf
 *.am text eol=lf
+/conftools/* text eol=lf
+
+# Buildable sources (mostly for docker on windows builds to pass):
+*.in text eol=lf
+*.pm text eol=lf
+/bin/* text eol=lf
 
 # Some files are binary always:
 *.png bin
@@ -13,4 +19,5 @@
 
 # The rest are assumed text sources with platform-dependent EOL being okay,
 # or we let Git guess otherwise:
-* text=auto
+#* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
Effectively force LF in checkouts, as hit during issue #589 exploration and building with Docker for Windows (so `COPY` carries over "wrong" EOLs).