### PR TITLE
Unencrypted to encrypted send support

### DIFF
--- a/bin/znapzend
+++ b/bin/znapzend
@@ -10,7 +10,7 @@ use Role::Tiny;
 use ZnapZend;
 my $VERSION = '0.dev'; #VERSION
 
-my %featureMap = map { $_ => 1 } qw(pfexec sudo oracleMode resume recvu compressed sendRaw lowmemRecurse zfsGetType skipIntermediates sendIntermediates forbidDestRollback);
+my %featureMap = map { $_ => 1 } qw(pfexec sudo oracleMode resume recvu compressed sendRaw lowmemRecurse zfsGetType skipIntermediates sendIntermediates forbidDestRollback disableEmbedded);
 
 sub main {
     my $opts = {};
@@ -195,7 +195,7 @@ B<znapzend> [I<options>...]
  --features=x           comma separated list of features to be enabled
                         (detailed in man page):
     oracleMode recvu compressed sendRaw lowmemRecurse zfsGetType
-    skipIntermediates sendIntermediates forbidDestRollback
+    skipIntermediates sendIntermediates forbidDestRollback disableEmbedded
  -i/-I                  a "zfs send" compatible on/off for skipIntermediates
  --rootExec=x           exec zfs with this command to obtain root privileges
                         (sudo or pfexec)
@@ -479,6 +479,10 @@ with receive_resume_token.
 
 If you have aborted a resumable-send, you should either do a resume-send using -t <token>
 to continue it or clear the half-received snapshot using zfs receive -A <filesystem>
+
+=item disableEmbedded
+
+when compression feature enabled, disableEmbedded removes -e option from zfs send parameters
 
 Example:
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -33,6 +33,7 @@ has compressed              => sub { 0 };
 has sendRaw                 => sub { 0 };
 has skipIntermediates       => sub { 0 };
 has forbidDestRollback      => sub { 0 };
+has disableEmbedded         => sub { 0 };
 has lowmemRecurse           => sub { 0 };
 has rootExec                => sub { q{} };
 has zfsGetType              => sub { 0 };
@@ -71,7 +72,7 @@ has zZfs => sub {
     my $self = shift;
     ZnapZend::ZFS->new(debug => $self->debug, noaction => $self->noaction,
         nodestroy => $self->nodestroy, oracleMode => $self->oracleMode,
-        resume => $self->resume,
+        resume => $self->resume, disableEmbedded => $self->disableEmbedded,
         recvu => $self->recvu, connectTimeout => $self->connectTimeout,
         lowmemRecurse => $self->lowmemRecurse, skipIntermediates => $self->skipIntermediates,
         rootExec => $self->rootExec, zfsGetType => $self->zfsGetType,

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -17,6 +17,7 @@ has compressed      => sub { 0 };
 has sendRaw         => sub { 0 };
 has skipIntermediates => sub { 0 };
 has forbidDestRollback => sub { 0 };
+has disableEmbedded => sub { 0 };
 has lowmemRecurse   => sub { 0 };
 has zfsGetType      => sub { 0 };
 has rootExec        => sub { q{} };
@@ -292,6 +293,7 @@ sub createDataSet {
 
     #just in case if someone asks to check '';
     return 0 if !$dataSet;
+    return 1;
 
     ($remote, $dataSet) = $splitHostDataSet->($dataSet);
     my @ssh = $self->$buildRemote($remote,
@@ -553,7 +555,13 @@ sub sendRecvSnapshots {
     my @recvOpt = $self->recvu ? qw(-u) : ();
     push @recvOpt, '-F' if $allowDestRollback;
     my $incrOpt = $self->skipIntermediates ? '-i' : '-I';
-    my @sendOpt = $self->compressed ? qw(-Lce) : ();
+    my @sendOpt = ();
+    if (not($self->compressed)) {
+    } elsif($self->disableEmbedded) {
+        @sendOpt = qw(-Lc);
+    } else {
+        @sendOpt = qw(-Lce);
+    }
     push @sendOpt, '-w' if $self->sendRaw;
     push @recvOpt, '-s' if $self->resume;
     my $remote;


### PR DESCRIPTION
There was multiple issues about sending from nonencrypted to encrypted dataset (#605, #565).

Main problem is that it is not possible rollback encrypted dataset on zfs recv. 
Fast workaround is return from function createDataSet before call zfs create. Dataset is than created on zfs recv without need to rollback. This is issue even when sending from encrypted to encrypted (#601, #495, #302)

What is the reason to explicitly create dataset before zfs recv?

Second problem is that compressed feature add "-Lce" but -e is incompatible with recv to encrypted dataset. Proposed fix is add new feature disableEmbedded which removes "-e" from options added by compressed feature.
As a new feature it will be backward compatible.

I am not perl programmer so it should be considered as draft or proof of concept.