### PR TITLE
Allow configuring `mbuffer` path and size separately for each destination (and source) system

### DIFF
--- a/.github/workflows/spelling/expect.txt
+++ b/.github/workflows/spelling/expect.txt
@@ -339,6 +339,7 @@ manpath
 manualsnap
 mariadb
 mariadblock
+Mbuf
 mbuffer
 mbuffersize
 MConfig

--- a/README.md
+++ b/README.md
@@ -197,6 +197,27 @@ and the I/O speeds of the storage and networking involved. As a rule of thumb,
 let it absorb at least a minute of I/O, so while one side of the ZFS dialog
 is deeply thinking, another can do its work.
 
+> **_NOTE:_**  Due to backwards-compatibility considerations, the legacy
+> `--mbuffer=...` setting applies by default to all destination datasets
+> (and to sender, in case of `--mbuffer=/path/to/mbuffer:port` variant).
+> This might work if needed programs are all found in `PATH` by the same
+> short name, but fails miserably if custom full path names are required
+> on different systems.
+>
+> To avoid this limitation, ZnapZend now allows to specify custom path
+> and buffer size settings individually for each source and destination
+> dataset in each backup/retention schedule configuration (using the
+> `znapzendzetup` program or `org.znapzend:src_mbuffer` etc. ZFS dataset
+> properties directly). The legacy configuration properties would now be
+> used as fallback defaults, and may emit warnings whenever they are
+> applied as such.
+>
+> With this feature in place, the sender may have the only `mbuffer`
+> running, without requiring one on the receiver (e.g. to limit impact
+> to RAM usage on the backup server). You may also run an mbuffer on
+> each side of the SSH tunnel, if networking latency is random and
+> carries a considerable impact.
+
 The remote system does not need anything other than ZFS functionality, an
 SSH server, a user account with prepared SSH key based log-in (optionally
 an unprivileged one with `zfs allow` settings on a particular target dataset

--- a/README.md
+++ b/README.md
@@ -197,6 +197,15 @@ and the I/O speeds of the storage and networking involved. As a rule of thumb,
 let it absorb at least a minute of I/O, so while one side of the ZFS dialog
 is deeply thinking, another can do its work.
 
+The remote system does not need anything other than ZFS functionality, an
+SSH server, a user account with prepared SSH key based log-in (optionally
+an unprivileged one with `zfs allow` settings on a particular target dataset
+dedicated to receiving your trees of backed-up datasets), and optionally the
+local implementation of the `mbuffer` program. Namely, as a frequently asked
+concern: the remote system *does not require* ZnapZend nor its dependencies
+(perl, etc.) to be installed. (It may however be installed - e.g. if used for
+snapshots of that remote system's own datasets.)
+
 Running
 -------
 

--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -101,7 +101,7 @@ sub parseArguments {
             $state = '';
             next;
         };
-        die "ERROR: dont know what to do with $_. check the syntax\n";
+        die "ERROR: don't know what to do with $_. check the syntax\n";
     }
 
     #check if we have a valid source as this is crucial
@@ -703,12 +703,22 @@ separator.
 
 Specify the path to your copy of the mbuffer utility.
 
+NOTE: with this option, the same path would be used for all remote
+destinations - this can misfire if they run different operating systems.
+
 =item B<--mbuffer>=I</usr/bin/mbuffer:31337>
 
-Specify the path to your copy of the mbuffer utility and the port used
-on the destination. Caution: znapzend will send the data directly
-from source mbuffer to destination mbuffer, thus data stream is B<not>
-encrypted.
+Specify the path to your copy of the mbuffer utility and
+the port used on the destination. Caution: znapzend will use SSH to
+set up the remote mbuffer receiver, but will send the snapshot data
+stream directly from source mbuffer to destination mbuffer. In other
+words, the data stream is B<not> encrypted. Use this only in a trusted
+LAN or over VPN, where you can safely avoid the overheads of an SSH
+tunnel.
+
+NOTE: with this option, the same path would be used for all remote
+destinations as well as the source system - this can misfire if they
+run different operating systems.
 
 =item B<--mbuffersize>=I<number>{B<b>|B<k>|B<M>|B<G>}
 

--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -80,6 +80,16 @@ sub parseArguments {
         #option must be a dataset or invalid
         $state eq 'src' && do {
             $backupSet{src} = $_;
+            $state = 'srcMbuf';
+            next;
+        };
+        $state eq 'srcMbuf' && do {
+            $backupSet{src_mbuffer} = $_;
+            $state = 'srcMbufSize';
+            next;
+        };
+        $state eq 'srcMbufSize' && do {
+            $backupSet{src_mbuffer_size} = $_;
             $state = '';
             next;
         };
@@ -98,6 +108,16 @@ sub parseArguments {
         #catch post-command if any
         $state eq 'pst' && do {
             $backupSet{'dst_' . $key . '_pstcmd'} = $_;
+            $state = 'dstMbuf';
+            next;
+        };
+        $state eq 'dstMbuf' && do {
+            $backupSet{'dst_' . $key . '_mbuffer'} = $_;
+            $state = 'dstMbufSize';
+            next;
+        };
+        $state eq 'dstMbufSize' && do {
+            $backupSet{'dst_' . $key . '_mbuffer_size'} = $_;
             $state = '';
             next;
         };
@@ -539,9 +559,10 @@ and where 'command' and its unique options is one of the following:
             [--post-snap-command=<command>] \
             [--tsformat=<format>] --donotask \
             [--send-delay=<time>] \
-            SRC plan dataset \
+            SRC plan dataset [src_mbuffer_path [src_mbuffer_size]] \
             [ DST[:key] plan [[user@]host:]dataset
-                [pre-send-command] [post-send-command] ]
+                [pre-send-command] [post-send-command] \
+                [dst_mbuffer_path[:port]] [dst_mbuffer_size] ]
 
             NOTE: If you specify [user@]host:dataset for remote replication
             over SSH, make use of ~/.ssh/config for any advanced options
@@ -555,9 +576,10 @@ and where 'command' and its unique options is one of the following:
             [--post-snap-command=<command>|off] \
             [--tsformat=<format>] --donotask \
             [--send-delay=<time>] \
-            SRC [plan] dataset \
+            SRC [plan] dataset [src_mbuffer_path [src_mbuffer_size]] \
             [ DST:key [plan] [dataset] \
-                [pre-send-command|off] [post-send-command|off] ]
+                [pre-send-command|off] [post-send-command|off] \
+                [dst_mbuffer_path[:port]|off] [dst_mbuffer_size] ]
 
     edit    <src_dataset>
 
@@ -701,14 +723,24 @@ separator.
 
 =item B<--mbuffer>=I</usr/bin/mbuffer>
 
-Specify the path to your copy of the mbuffer utility.
+DEPRECATED: Specify the path to your copy of the mbuffer utility.
 
 NOTE: with this option, the same path would be used for all remote
 destinations - this can misfire if they run different operating systems.
 
+It is currently recommended to define individual B<dst_mbuffer_path>
+options for each separate destination in each dataset configuration.
+The B<--mbuffer> value would be used as a fallback default for those.
+
+Per legacy-default behavior, the mbuffer program was not used by the
+sender (unless using a dedicated port, see below). Nowadays it is
+possible to specify it instead of (or in addition to) a destination
+side mbuffer, using the B<src_mbuffer_path> in each source dataset
+configuration.
+
 =item B<--mbuffer>=I</usr/bin/mbuffer:31337>
 
-Specify the path to your copy of the mbuffer utility and
+DEPRECATED: Specify the path to your copy of the mbuffer utility and
 the port used on the destination. Caution: znapzend will use SSH to
 set up the remote mbuffer receiver, but will send the snapshot data
 stream directly from source mbuffer to destination mbuffer. In other
@@ -719,6 +751,11 @@ tunnel.
 NOTE: with this option, the same path would be used for all remote
 destinations as well as the source system - this can misfire if they
 run different operating systems.
+
+It is currently recommended to define individual B<*_mbuffer_path>
+options for each source and each separate destination in each dataset
+configuration. The B<--mbuffer> value would be used as a fallback
+default for those (with only path component for the source).
 
 =item B<--mbuffersize>=I<number>{B<b>|B<k>|B<M>|B<G>}
 
@@ -732,6 +769,10 @@ To specify a mbuffer size of 100MB:
  --mbuffersize=100M
 
 If not set, the buffer size defaults to 1GB.
+
+It is currently suggested to define individual B<mbuffer_size> options for
+each source and each separate destination in each dataset configuration.
+The B<--mbuffer-size> value would be used as a fallback default for those.
 
 =item B<--donotask>
 
@@ -830,11 +871,13 @@ create a complex backup task
        --pre-snap-command="/bin/sh /usr/local/bin/lock_flush_db.sh" \
        --post-snap-command="/bin/sh /usr/local/bin/unlock_db.sh" \
        SRC '7d=>1h,30d=>4h,90d=>1d' tank/home \
+          "/usr/bin/mbuffer" "128M" \
        DST:a '7d=>1h,30d=>4h,90d=>1d,1y=>1w,10y=>1month' backup/home \
        DST:b '7d=>1h,30d=>4h,90d=>1d,1y=>1w,10y=>1month' \
           root@bserv:backup/home \
           "/root/znapzend.sh dst_b pool on" \
-          "/root/znapzend.sh dst_b pool off"
+          "/root/znapzend.sh dst_b pool off" \
+          "/opt/bin64/mbuffer" "4G"
 
 
 copy the setup from one fileset to another

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -597,7 +597,8 @@ my $sendRecvCleanup = sub {
                                             $lastSnapshotToSee = ${$srcSnapshots}[$seenX];
                                         }
                                         $self->zZfs->sendRecvSnapshots($srcDataSet, $dstDataSet, $dst,
-                                                $backupSet->{mbuffer}, $backupSet->{mbuffer_size},
+                                                $backupSet->{src_mbuffer}, $backupSet->{src_mbuffer_size},
+                                                $backupSet->{"dst_$key" . '_mbuffer'}, $backupSet->{"dst_$key" . '_mbuffer_size'},
                                                 $backupSet->{snapSendFilter}, $lastSnapshotToSee,
                                                 ( $backupSet->{"dst_$key" . '_justCreated'} ? 1 : ($doPromote > 1 ? $doPromote : undef ) )
                                             );
@@ -626,7 +627,8 @@ my $sendRecvCleanup = sub {
                     # Note this can fail if we forbidDestRollback and there are
                     # snapshots or data on dst newer than the last common snap.
                     $self->zZfs->sendRecvSnapshots($srcDataSet, $dstDataSet, $dst,
-                        $backupSet->{mbuffer}, $backupSet->{mbuffer_size},
+                        $backupSet->{src_mbuffer}, $backupSet->{src_mbuffer_size},
+                        $backupSet->{"dst_$key" . '_mbuffer'}, $backupSet->{"dst_$key" . '_mbuffer_size'},
                         $backupSet->{snapSendFilter}, undef,
                         ( $backupSet->{"dst_$key" . '_justCreated'} ? 1 : undef )
                         );

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -148,6 +148,45 @@ my $checkBackupSets = sub {
                     or die "ERROR: property $prop is not valid on dataset " . $backupSet->{src} . "\n";
             }
         }
+
+        # mbuffer properties not set for source? legacy behavior was to not use
+        # any on the sender, except when in port-to-port mode
+        if (!exists($backupSet->{src_mbuffer}) or !($backupSet->{src_mbuffer})) {
+            # Have *something* defined to avoid further exists() checks at least
+            $backupSet->{src_mbuffer} = undef;
+            if ($backupSet->{mbuffer}) {
+                if ($backupSet->{mbuffer} eq 'off') {
+                    # Only use the setting for source if legacy "off" is set
+                    $backupSet->{src_mbuffer} = $backupSet->{mbuffer};
+                    $self->zLog->info("WARNING: property 'src_mbuffer' not set on backup for " . $backupSet->{src} . ", inheriting 'off' from legacy 'mbuffer'");
+                } else {
+                    my ($mbuffer, $mbufferPort) = split /:/, $backupSet->{mbuffer}, 2;
+                    #check if port is numeric
+                    if ($mbufferPort &&
+                        $mbufferPort =~ /^\d{1,5}$/ && int($mbufferPort) < 65535
+                    ) {
+                        # Only use the setting for source program if the legacy
+                        # "/path/to/mbuffer:port" is set (note we would use a
+                        # port defined by each destination separately - maybe
+                        # inherited from the legacy setting, maybe re-defined
+                        # locally or even avoided for that destination link).
+                        $backupSet->{src_mbuffer} = $mbuffer;
+                        $self->zLog->info("WARNING: property 'src_mbuffer' not set on backup for " . $backupSet->{src} . ", inheriting path from legacy 'mbuffer': " . $backupSet->{src_mbuffer});
+                    }
+                }
+            }
+        }
+        if ($backupSet->{src_mbuffer}) {
+            if (!($self->zfs->fileExistsAndExec($backupSet->{src_mbuffer}))) {
+                warn "*** WARNING: executable '$backupSet->{src_mbuffer}' does not exist on source system, will ignore\n\n";
+                $backupSet->{src_mbuffer} = undef;
+            }
+        }
+        if (!exists($backupSet->{src_mbuffer_size}) or !($backupSet->{src_mbuffer_size})) {
+            $backupSet->{src_mbuffer_size} = $backupSet->{mbuffer_size};
+            $self->zLog->info("WARNING: property 'src_mbuffer_size' not set on backup for " . $backupSet->{src} . ", inheriting from legacy 'mbuffer_size': " . $backupSet->{src_mbuffer_size}) if $backupSet->{src_mbuffer_size};
+        }
+
         #check destination plans and datasets
         for my $dst (grep { /^dst_[^_]+$/ } keys %$backupSet){
             #store backup destination validity. will be checked where used
@@ -158,17 +197,33 @@ my $checkBackupSets = sub {
 
             $backupSet->{$dst . '_plan'} = $self->$checkBackupPlan($backupSet->{$dst . '_plan'});
 
+            # mbuffer properties not set for destination? inherit the legacy default ones.
+            if (!exists($backupSet->{$dst . '_mbuffer'}) or !($backupSet->{$dst . '_mbuffer'})) {
+                ###if ($backupSet->{mbuffer}) {
+                    $backupSet->{$dst . '_mbuffer'} = $backupSet->{mbuffer};
+                ### Do not preclude inheritance when legacy setting changes
+                ###} else {
+                ###    $backupSet->{$dst . '_mbuffer'} = 'off';
+                ###}
+                $self->zLog->info("WARNING: property '" . $dst . "_mbuffer' not set on backup for " . $backupSet->{src} . ", inheriting path[:port] from legacy 'mbuffer': " . $backupSet->{$dst . '_mbuffer'}) if $backupSet->{$dst . '_mbuffer'};
+            }
+            if (!exists($backupSet->{$dst . '_mbuffer_size'}) or !($backupSet->{$dst . '_mbuffer_size'})) {
+                $backupSet->{$dst . '_mbuffer_size'} = $backupSet->{mbuffer_size};
+                $self->zLog->info("WARNING: property '" . $dst . "_mbuffer_size' not set on backup for " . $backupSet->{src} . ", inheriting from legacy 'mbuffer_size': " . $backupSet->{$dst . '_mbuffer_size'}) if $backupSet->{$dst . '_mbuffer_size'};
+            }
+
             # mbuffer property set? check if executable is available on remote host
-            if ($backupSet->{mbuffer} ne 'off'){
-                my ($mbuffer, $mbufferPort) = split /:/, $backupSet->{mbuffer}, 2;
+            if ($backupSet->{$dst . '_mbuffer'} ne 'off') {
+                my ($mbuffer, $mbufferPort) = split /:/, $backupSet->{$dst . '_mbuffer'}, 2;
                 my ($remote, $dataset) = $splitHostDataSet->($backupSet->{$dst});
                 my $file = ($remote ? "$remote:" : '') . $mbuffer;
                 $self->zfs->fileExistsAndExec($file)
-                    or warn "*** WARNING: executable '$mbuffer' does not exist" . ($remote ? " on $remote\n\n" : "\n\n");
+                    or warn "*** WARNING: executable '$mbuffer' does not exist on " . ($remote ? "remote $remote" : "local") . " system, zfs receive can fail\n\n";
+                    # TOTHINK: Reset to 'off'/undef and ignore the validity checks below?
 
                 #check if mbuffer size is valid
-                $backupSet->{mbuffer_size} =~ /^\d+[bkMG%]?$/
-                    or die "ERROR: mbuffer size '" . $backupSet->{mbuffer_size} . "' invalid\n";
+                $backupSet->{$dst . '_mbuffer_size'} =~ /^\d+[bkMG%]?$/
+                    or die "ERROR: mbuffer size '" . $backupSet->{$dst . '_mbuffer_size'} . "' invalid\n";
                 #check if port is numeric
                 $mbufferPort && do {
                     $mbufferPort =~ /^\d{1,5}$/ && int($mbufferPort) < 65535


### PR DESCRIPTION
Closes: #629

See rationale and investigation details in the linked issue above.

Practical run with legacy-only setup (and debug mode):
````
...
# zfs list -H -o name -t filesystem,volume rpool/home/abuild
[2024-01-16 14:33:55.30202] [623247] [info] WARNING: property 'src_mbuffer_size' not set on backup for rpool/home/abuild, inheriting from legacy 'mbuffer_size': 128M
# ssh -o batchMode=yes -o ConnectTimeout=30 znapzend zfs list -H -o name -t 'filesystem,volume' pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild
[2024-01-16 14:33:55.59895] [623247] [info] WARNING: property 'dst_0_mbuffer' not set on backup for rpool/home/abuild, inheriting path[:port] from legacy 'mbuffer': mbuffer
[2024-01-16 14:33:55.59917] [623247] [info] WARNING: property 'dst_0_mbuffer_size' not set on backup for rpool/home/abuild, inheriting from legacy 'mbuffer_size': 128M
# ssh -o batchMode=yes -o ConnectTimeout=30 znapzend test -x mbuffer || ssh -o batchMode=yes -o ConnectTimeout=30 znapzend command -v mbuffer
WARNING: Only found executable file basename 'mbuffer' with 'command -v': /home/znapzend-ci-oi/bin/mbuffer

...

[2024-01-16 14:36:25.82687] [624979] [debug] sending snapshots from rpool/home/abuild to znapzend:pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild
[2024-01-16 14:36:25.82715] [624979] [debug] Are we sending "--since"? since=="0", skipIntermediates=="0", forbidDestRollback=="0", justCreated=="false"
# zfs list -H -o name -t snapshot -s creation -d 1 rpool/home/abuild
# ssh -o batchMode=yes -o ConnectTimeout=30 znapzend zfs list -H -o name -t snapshot -s creation -d 1 pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild
# zfs send -Lce -I 'rpool/home/abuild@znapzend-auto-2024-01-16T11:51:05Z' 'rpool/home/abuild@znapzend-auto-2024-01-16T14:36:24Z'|ssh -o batchMode=yes -o ConnectTimeout=30 znapzend 'mbuffer -q -s 256k -W 600 -m 128M|zfs recv -u -F pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild'
# zfs list -H -o name -t snapshot rpool/home/abuild@znapzend-auto-2024-01-16T14:36:24Z
# zfs set org.znapzend:dst_0_synced=1 rpool/home/abuild@znapzend-auto-2024-01-16T14:36:24Z
# zfs set org.znapzend:dst_0=znapzend:pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild rpool/home/abuild@znapzend-auto-2024-01-16T14:36:24Z
````

And for a setup with dedicated values:
````
src# zfs set org.znapzend:src_mbuffer=`which mbuffer` rpool/home
src# zfs set org.znapzend:dst_0_mbuffer="/home/znapzend-ci-oi/bin/mbuffer" rpool/home
src# zfs set org.znapzend:dst_0_mbuffer_size=1G rpool/home
src# zfs set org.znapzend:src_mbuffer_size=128M rpool/home

src# ./bin/znapzend --pidfile=/dev/null --features=compressed,recvu,sendIntermediates --inherited --runonce=rpool/home/abuild --debug
...
[2024-01-16 14:40:13.89197] [627314] [debug] === getDataSetProperties():
        Collected: $VAR1 = {
          'pre_znap_cmd' => 'off',
          'recursive' => 'on',
          'src_mbuffer_size' => '128M',
          'dst_0_mbuffer' => '/home/znapzend-ci-oi/bin/mbuffer',
          'dst_0_plan' => '1weeks=>1days,1months=>1weeks,1years=>1months,10years=>6months',
          'zend_delay' => '0',
          'tsformat' => 'znapzend-auto-%Y-%m-%dT%H:%M:%SZ',
          'post_znap_cmd' => 'off',
          'mbuffer' => 'mbuffer',
          'enabled' => 'on',
          'mbuffer_size' => '128M',
          'src' => 'rpool/home/abuild',
          'dst_0_mbuffer_size' => '1G',
          'src_plan' => '1weeks=>1days,1months=>1weeks,1years=>1months,10years=>6months',
          'src_mbuffer' => '/usr/bin/mbuffer',
          'dst_0' => 'znapzend:pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild'
        };
# zfs list -H -o name -t filesystem,volume rpool/home/abuild
# test -x /usr/bin/mbuffer || command -v /usr/bin/mbuffer
# ssh -o batchMode=yes -o ConnectTimeout=30 znapzend zfs list -H -o name -t 'filesystem,volume' pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild
# ssh -o batchMode=yes -o ConnectTimeout=30 znapzend test -x /home/znapzend-ci-oi/bin/mbuffer || ssh -o batchMode=yes -o ConnectTimeout=30 znapzend command -v /home/znapzend-ci-oi/bin/mbuffer
=== getBackupSet() : got 1 dataset(s) with a local or inherited backup plan
...
# zfs send -Lce -I 'rpool/home/abuild@znapzend-auto-2024-01-16T14:36:24Z' 'rpool/home/abuild@znapzend-auto-2024-01-16T14:40:14Z'|ssh -o batchMode=yes -o ConnectTimeout=30 znapzend '/home/znapzend-ci-oi/bin/mbuffer -q -s 256k -W 600 -m 1G|zfs recv -u -F pond/export/DUMP/NUTCI/znapzend/ci-deb/rpool/home/abuild'
````