### PR TITLE
[RFE] `znapzendsetup` : support `dst_N_enable` setting

### DIFF
--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -88,6 +88,14 @@ sub parseArguments {
             $state = 'pre';
             next;
         };
+        #catch 'dst(...) on|off' if any
+        ($state eq 'pre' || $state eq 'pst' || $state eq 'dst-enabled') && do {
+            if ($_ eq 'off' || $_ eq 'on') {
+                $backupSet{'dst_' . $key . '_enabled'} = $_;
+                $state = '';
+                next;
+            }; # else fall through to state-processing or to die() below
+        };
         #catch pre-command if any
         $state eq 'pre' && do {
             $backupSet{'dst_' . $key . '_precmd'} = $_;
@@ -97,9 +105,10 @@ sub parseArguments {
         #catch post-command if any
         $state eq 'pst' && do {
             $backupSet{'dst_' . $key . '_pstcmd'} = $_;
-            $state = '';
+            $state = 'dst_enabled';
             next;
         };
+
         die "ERROR: dont know what to do with $_. check the syntax\n";
     }
 


### PR DESCRIPTION
Looking through my old branches, found this bit: the codebase (lib, tests) supports a `dst_N_enable` setting if present among ZFS dataset properties for the backup/retention schedule; however there is no "API way" to toggle this right in the new setting (there is a separate `znapzendzetup enable-dst <src_dataset> <DST_key>` at this time).

Being 5 years old, the idea would need brushing up:
* [ ] docs, manpage examples
* [ ] embed into the stack of DST settings (e.g. changed for mbuffer with #632/#630 recently)

First and foremost, the question is if it is worth the effort (is useful)? :)