### PR TITLE
Extend `--autoCreation` effect (or default lack thereof) to newly appearing sub-datasets

### DIFF
--- a/.github/workflows/spelling/expect.txt
+++ b/.github/workflows/spelling/expect.txt
@@ -374,6 +374,7 @@ newestbe
 nf
 nh
 noaction
+noauto
 nobase
 nodelay
 nodestroy

--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ znapzend (0.21.3) unstable; urgency=medium
   * Update self-tests with verification that [[user@]host:]dataset[:with-colons][@snap[:with-colons]] string decoding yields expected results
   * Fixed CI recipes and contents for spell-checker
   * Added rc-script and integration documentation for FreeBSD and similar platforms
+  * Extended `--autoCreation` effect (or lack thereof) to newly appearing sub-datasets; added a `--noautoCreation` option to help override configuration file settings (where used)
 
  -- Jim Klimov <jimklimov@gmail.com>  Tue, 9 Jan 2024 13:42:28 +0100
 

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -16,7 +16,7 @@ sub main {
     my $opts = {};
     GetOptions($opts, qw(help|h man debug|d noaction|n nodestroy features=s),
         qw(sudo pfexec rootExec=s daemonize pidfile=s logto=s loglevel=s),
-        qw(runonce:s connectTimeout=s timeWarp=i nodelay autoCreation version),
+        qw(runonce:s connectTimeout=s timeWarp=i nodelay autoCreation noautoCreation version),
         qw(forcedSnapshotSuffix=s forbidDestRollback),
         qw(skipIntermediates|i sendIntermediates|I),
             # Note: the intended usage is either via feature as done
@@ -83,6 +83,15 @@ sub main {
         $opts->{forbidDestRollback} = 1;
     } else {
         $opts->{forbidDestRollback} = 0;
+    }
+
+    if (defined($opts->{noautoCreation})) {
+        $opts->{autoCreation} = 0;
+        delete $opts->{noautoCreation};
+    } else {
+        if (defined($opts->{autoCreation})) {
+            $opts->{autoCreation} = 1;
+        }
     }
 
     if (defined($opts->{sinceForced}) && ($opts->{sinceForced} eq '')) {
@@ -202,6 +211,8 @@ B<znapzend> [I<options>...]
  --connectTimeout=x     sets the ConnectTimeout for ssh commands
  --autoCreation         automatically create dataset on destination if it does
                         not exist
+ --noautoCreation       avoid automatically creating a dataset on destination
+                        if it does not exist (default)
  --timeWarp=x           shift znapzend's sense of NOW into the future
                         by x seconds
  --skipOnPreSnapCmdFail skip snapshots if the pre-snap-command fails
@@ -609,6 +620,12 @@ sets the ssh connection timeout (in seconds)
 =item B<--autoCreation>
 
 Automatically create a dataset on a destination host if it's not there yet.
+
+=item B<--noautoCreation>
+
+Avoid automatically creating a dataset on a destination host if it's not
+there yet. This is the default behavior; the option is available to help
+explicitly override a setting inherited from a configuration file, etc.
 
 =item B<--timeWarp>=x
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -429,7 +429,7 @@ my $sendRecvCleanup = sub {
                 }
                 ( $backupSet->{"dst_$key" . '_valid'} || ($self->sendRaw && $self->autoCreation) ) or do {
                     my $errmsg = "destination '" . $backupSet->{"dst_$key"}
-                        . "' does not exist or is offline. ignoring it for this round...";
+                        . "' does not exist or is offline; ignoring it for this round...";
                     $self->zLog->warn($errmsg);
                     push (@sendFailed, $errmsg);
                     $thisSendFailed = 1;

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -274,6 +274,8 @@ my $refreshBackupPlans = sub {
                             . "' does not exist or is offline. will be rechecked every run..."
                             . ( $self->autoCreation ? "" : " Consider running znapzend --autoCreation" ) );
                 };
+
+                $self->zLog->debug('refreshBackupPlans(): detected dst_' . $key . '_valid status for ' . $backupSet->{"dst_$key"} . ': ' . $backupSet->{"dst_$key" . '_valid'}) if ($self->debug);
             }
             $backupSet->{"dst$key" . 'PlanHash'}
                 = $self->zTime->backupPlanToHash($backupSet->{"dst_$key" . '_plan'});
@@ -431,6 +433,8 @@ my $sendRecvCleanup = sub {
                     next;
                 };
             };
+
+            $self->zLog->debug('sendRecvCleanup(): detected dst_' . $key . '_valid status for ' . $backupSet->{"dst_$key"} . ': ' . $backupSet->{"dst_$key" . '_valid'}) if ($self->debug);
         }
 
         #sending loop through all subdatasets
@@ -452,8 +456,12 @@ my $sendRecvCleanup = sub {
                         'since=="' . $self->since . '"'.
                         ', skipIntermediates=="' . $self->skipIntermediates . '"' .
                         ', forbidDestRollback=="' . $self->forbidDestRollback . '"' .
+                        ', autoCreation=="' . $self->autoCreation . '"' .
+                        ', sendRaw=="' . $self->sendRaw . '"' .
+                        ', valid=="' . ( $backupSet->{"dst_$key" . '_valid'} ? "true" : "false" ) . '"' .
                         ', justCreated=="' . ( $backupSet->{"dst_$key" . '_justCreated'} ? "true" : "false" ) . '"'
                         ) if $self->debug;
+
                     if ($self->since) {
                         # Make sure that if we use the "--sinceForced=X" or
                         # "--since=X" option, this named snapshot exists (or

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -191,6 +191,7 @@ my $checkBackupSets = sub {
         for my $dst (grep { /^dst_[^_]+$/ } keys %$backupSet){
             #store backup destination validity. will be checked where used
             $backupSet->{$dst . '_valid'} = $self->zfs->dataSetExists($backupSet->{$dst});
+            $self->zLog->debug('checkBackupSets(): detected ' . $dst . '_valid status for ' . $backupSet->{$dst} . ': ' . $backupSet->{$dst . '_valid'}) if ($self->debug);
 
             #if a backup destination is given, we also need a plan
             $backupSet->{$dst . '_plan'} or die "ERROR: no backup plan given for destination\n";

--- a/man/znapzend.1
+++ b/man/znapzend.1
@@ -176,6 +176,8 @@ znapzend \- znapzend daemon
 \& \-\-connectTimeout=x     sets the ConnectTimeout for ssh commands
 \& \-\-autoCreation         automatically create dataset on destination if it does
 \&                        not exist
+\& \-\-noautoCreation       avoid automatically creating a dataset on destination
+\&                        if it does not exist (default)
 \& \-\-timeWarp=x           shift znapzend\*(Aqs sense of NOW into the future
 \&                        by x seconds
 \& \-\-skipOnPreSnapCmdFail skip snapshots if the pre\-snap\-command fails
@@ -569,6 +571,11 @@ sets the ssh connection timeout (in seconds)
 .IP "\fB\-\-autoCreation\fR" 4
 .IX Item "--autoCreation"
 Automatically create a dataset on a destination host if it's not there yet.
+.IP "\fB\-\-noautoCreation\fR" 4
+.IX Item "--noautoCreation"
+Avoid automatically creating a dataset on a destination host if it's not
+there yet. This is the default behavior; the option is available to help
+explicitly override a setting inherited from a configuration file, etc.
 .IP "\fB\-\-timeWarp\fR=x" 4
 .IX Item "--timeWarp=x"
 Shift ZnapZend's sense of time into the future by x seconds.


### PR DESCRIPTION
For example, avoid unexpected creation of avoidably large replicas of root datasets where promotable clones of boot environments are used (currently `znapzend` makes a new full `zfs send`, not a clone+promote operation - see #503 and others after it).

Also added a `--noautoCreation` option to help override configuration file settings (where used), primarily to help test this change locally.

NOTE: I have a nagging feeling that the default value for this setting belongs in ZFS properties (per-destination) rather than in CLI as one toggle to rule them all (can be kept for one-off overrides). Maybe another PR would address that, more so if I get to solving #503 directly. UPDATE: See #637 for zfs props approach.