### PR TITLE
Support `dst_N_autocreation` ZFS properties

### DIFF
--- a/.github/workflows/spelling/expect.txt
+++ b/.github/workflows/spelling/expect.txt
@@ -26,6 +26,7 @@ attr
 austingroupbugs
 autocommit
 autoconf
+autocreation
 autom
 automake
 automounting

--- a/.github/workflows/spelling/expect.txt
+++ b/.github/workflows/spelling/expect.txt
@@ -72,6 +72,7 @@ Bznapzendzetup
 Bznapzendztatz
 canmount
 CBuilder
+cdn
 cfg
 cgi
 cgit

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ znapzend (0.21.3) unstable; urgency=medium
   * Fixed CI recipes and contents for spell-checker
   * Added rc-script and integration documentation for FreeBSD and similar platforms
   * Extended `--autoCreation` effect (or lack thereof) to newly appearing sub-datasets; added a `--noautoCreation` option to help override configuration file settings (where used)
+  * Introduced `dst_N_autocreation` setting via ZFS properties (per-destination, inheritable)
 
  -- Jim Klimov <jimklimov@gmail.com>  Tue, 9 Jan 2024 13:42:28 +0100
 

--- a/bin/znapzend
+++ b/bin/znapzend
@@ -85,6 +85,9 @@ sub main {
         $opts->{forbidDestRollback} = 0;
     }
 
+    # Note: default is "undef" to use a ZFS property dst_N_autocreation
+    # (lower-case "c" in the name) if present; finally assumes 0 (false)
+    # if not set in any configuration source for a particular dataset.
     if (defined($opts->{noautoCreation})) {
         $opts->{autoCreation} = 0;
         delete $opts->{noautoCreation};

--- a/bin/znapzendzetup
+++ b/bin/znapzendzetup
@@ -402,6 +402,54 @@ sub main {
 
         last;
     };
+    /^enable-dst-autocreation$/ && do {
+        $opts->{dst} = pop @ARGV;
+        $opts->{src} = pop @ARGV;
+        if (!defined $opts->{src}) {
+            pod2usage(-exitval => 'NOEXIT');
+            die ("ERROR: source argument for option $mainOpt was not provided\n");
+        }
+        if (!defined $opts->{dst}) {
+            pod2usage(-exitval => 'NOEXIT');
+            die ("ERROR: destination argument for option $mainOpt was not provided\n");
+        }
+        $zConfig->enableBackupSetDstAutoCreation($opts->{src}, $opts->{dst})
+            or die "ERROR: cannot enable backup config for $opts->{src} destination $opts->{dst}. Did you create this config?\n";
+
+        last;
+    };
+    /^disable-dst-autocreation$/ && do {
+        $opts->{dst} = pop @ARGV;
+        $opts->{src} = pop @ARGV;
+        if (!defined $opts->{src}) {
+            pod2usage(-exitval => 'NOEXIT');
+            die ("ERROR: source argument for option $mainOpt was not provided\n");
+        }
+        if (!defined $opts->{dst}) {
+            pod2usage(-exitval => 'NOEXIT');
+            die ("ERROR: destination argument for option $mainOpt was not provided\n");
+        }
+        $zConfig->disableBackupSetDstAutoCreation($opts->{src}, $opts->{dst})
+            or die "ERROR: cannot disable backup config for $opts->{src} destination $opts->{dst}. Did you create this config?\n";
+
+        last;
+    };
+    /^inherit-dst-autocreation$/ && do {
+        $opts->{dst} = pop @ARGV;
+        $opts->{src} = pop @ARGV;
+        if (!defined $opts->{src}) {
+            pod2usage(-exitval => 'NOEXIT');
+            die ("ERROR: source argument for option $mainOpt was not provided\n");
+        }
+        if (!defined $opts->{dst}) {
+            pod2usage(-exitval => 'NOEXIT');
+            die ("ERROR: destination argument for option $mainOpt was not provided\n");
+        }
+        $zConfig->inheritBackupSetDstAutoCreation($opts->{src}, $opts->{dst})
+            or die "ERROR: cannot disable backup config for $opts->{src} destination $opts->{dst}. Did you create this config?\n";
+
+        last;
+    };
     /^list$/ && do {
         GetOptions($opts, (@ROOT_EXEC_OPTIONS, qw(recursive|r inherited))) or exit 1;
 
@@ -590,6 +638,12 @@ and where 'command' and its unique options is one of the following:
     enable-dst  <src_dataset> <DST_key>
 
     disable-dst <src_dataset> <DST_key>
+
+    enable-dst-autocreation  <src_dataset> <DST_key>
+
+    disable-dst-autocreation <src_dataset> <DST_key>
+
+    inherit-dst-autocreation  <src_dataset> <DST_key>
 
     list    [--recursive] [--inherited] [src_dataset...]
 

--- a/lib/ZnapZend.pm
+++ b/lib/ZnapZend.pm
@@ -452,9 +452,11 @@ my $sendRecvCleanup = sub {
                 ( $backupSet->{"dst_$key" . '_valid'} || ($self->sendRaw && $autoCreation) ) or do {
                     my $errmsg = "destination '" . $backupSet->{"dst_$key"}
                         . "' does not exist or is offline; ignoring it for this round...";
-                    $self->zLog->warn($errmsg);
+                    # Avoid spamming for every loop cycle, if we do not have
+                    # the dataset and know we do not intend to auto-create it
+                    $self->zLog->warn($errmsg) if ($autoCreation or $self->debug);
                     if (!$autoCreation) {
-                        $self->zLog->warn("Autocreation is disabled for this dataset or whole run, so skipping without error");
+                        $self->zLog->warn("Autocreation is disabled for this dataset or whole run, so skipping without error") if ($self->debug);
                     } else {
                         push (@sendFailed, $errmsg);
                         $thisSendFailed = 1;
@@ -505,9 +507,11 @@ my $sendRecvCleanup = sub {
                     . "' does not exist or is offline; ignoring it for this round... Consider "
                     . ( $autoCreation || $self->sendRaw ? "" : "running znapzend --autoCreation or " )
                     . "disabling this dataset from znapzend handling.";
-                $self->zLog->warn($errmsg);
+                # Avoid spamming for every loop cycle, if we do not have
+                # the dataset and know we do not intend to auto-create it
+                $self->zLog->warn($errmsg) if ($autoCreation or $self->debug);
                 if (!$autoCreation) {
-                    $self->zLog->warn("Autocreation is disabled for this dataset or whole run, so skipping without error");
+                    $self->zLog->warn("Autocreation is disabled for this dataset or whole run, so skipping without error") if ($self->debug);
                 } else {
                     push (@sendFailed, $errmsg);
                     $thisSendFailed = 1;

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -91,7 +91,7 @@ my $checkBackupSets = sub {
         # local "org.znapzend:..." property), or just once for a single
         # "--runonce=..." backupSet (not recursing into children with
         # their exceptional settings then, unless also "--recursive").
-
+        #
         # In case there is only one property on this dataset, which is the
         # "enabled" flag and is set to "off"; consider it a normal situation
         # and do not even notify it. This situation will appear when there
@@ -99,11 +99,18 @@ my $checkBackupSets = sub {
         # Note: backupSets will have at least the key "src". Therefore, we
         # need to skip the dataset if there are two properties and one of
         # them is "enabled".
-
+        #
+        # Similarly for datasets which declare both the "enabled" flag and
+        # the "recursion" flag (e.g. to prune whole dataset sub-trees from
+        # backing up with znapzend) by configuring only the root of such
+        # sub-tree.
+        #
         # Likewise, skip checking datasets (enabled or not) that have only
         # an autoCreation setting for particular destination(s); note that
         # ZFS property names must be lower-case (so "c" is small here).
-        # So we prepare a filtered set of configuration keys:
+        # Hence we prepare a filtered set of configuration keys ("dst" name
+        # tags are user-provided and not too predictable), so only "src"
+        # would remain there:
         my @backupSetKeysFiltered = grep (!/^dst_[^_]+_autocreation$/, keys(%{$backupSet}));
         my $backupSetKeysFiltered = scalar(@backupSetKeysFiltered);
         $self->zLog->debug("#checkBackupSets# backupSetKeysFiltered "
@@ -119,10 +126,7 @@ my $checkBackupSets = sub {
             next;
         }
 
-        # Similarly for datasets which declare both the "enabled" flag and
-        # the "recursion" flag (e.g. to prune whole dataset sub-trees from
-        # backing up with znapzend) by configuring only the root of such
-        # sub-tree.
+        # "src", "enabled" and "recursion" (after disregarding autocreation):
         if ($backupSetKeysFiltered eq 3 && exists($backupSet->{"enabled"}) && exists($backupSet->{"recursive"})){
             next;
         }

--- a/lib/ZnapZend/Config.pm
+++ b/lib/ZnapZend/Config.pm
@@ -520,6 +520,142 @@ sub disableBackupSetDst {
     return 0;
 }
 
+sub enableBackupSetDstAutoCreation {
+    my $self = shift;
+    my $dataSet = shift;
+    my $dest = shift;
+    my $recurse = shift; # may be undef
+    my $inherit = shift; # may be undef
+
+    $self->zfs->dataSetExists($dataSet) or die "ERROR: dataset $dataSet does not exist\n";
+
+    $self->backupSets($self->zfs->getDataSetProperties($dataSet, $recurse, $inherit));
+
+    if (@{$self->backupSets}){
+        my %cfg = %{$self->backupSets->[0]};
+
+        if ( !($dest =~ /^dst_[^_]+$/) ) {
+            if ($cfg{'dst_' . $dest}) {
+                # User passed valid key of the destination config,
+                # convert to zfs attribute/perl struct name part
+                $dest = 'dst_' . $dest;
+            } elsif ($dest =~ /^DST:/) {
+                my $desttemp = $dest;
+                $desttemp =~ s/^DST:// ;
+                if ($cfg{'dst_' . $desttemp}) {
+                    # User passed valid key of the destination config,
+                    # convert to zfs attribute/perl struct name part
+                    $dest = 'dst_' . $desttemp;
+                }
+            }
+            # TODO: Else search by value of 'dst_N' as a "(remote@)dataset"
+        }
+
+        if ($cfg{$dest}) {
+            if ($cfg{$dest . '_autocreation'}) {
+                $cfg{$dest . '_autocreation'} = 'on';
+            }
+        } else {
+            die "ERROR: dataset $dataSet backup plan does not have destination $dest\n";
+        }
+        $self->setBackupSet(\%cfg);
+
+        return 1;
+    }
+
+    return 0;
+}
+
+sub disableBackupSetDstAutoCreation {
+    my $self = shift;
+    my $dataSet = shift;
+    my $dest = shift;
+    my $recurse = shift; # may be undef
+    my $inherit = shift; # may be undef
+
+    $self->zfs->dataSetExists($dataSet) or die "ERROR: dataset $dataSet does not exist\n";
+
+    $self->backupSets($self->zfs->getDataSetProperties($dataSet, $recurse, $inherit));
+
+    if (@{$self->backupSets}){
+        my %cfg = %{$self->backupSets->[0]};
+
+        if ( !($dest =~ /^dst_[^_]+$/) ) {
+            if ($cfg{'dst_' . $dest}) {
+                # User passed valid key of the destination config,
+                # convert to zfs attribute/perl struct name part
+                $dest = 'dst_' . $dest;
+            } elsif ($dest =~ /^DST:/) {
+                my $desttemp = $dest;
+                $desttemp =~ s/^DST:// ;
+                if ($cfg{'dst_' . $desttemp}) {
+                    # User passed valid key of the destination config,
+                    # convert to zfs attribute/perl struct name part
+                    $dest = 'dst_' . $desttemp;
+                }
+            }
+            # TODO: Else search by value of 'dst_N' as a "(remote@)dataset"
+        }
+
+        if ($cfg{$dest}) {
+            $cfg{$dest . '_autocreation'} = 'off';
+        } else {
+            die "ERROR: dataset $dataSet backup plan does not have destination $dest\n";
+        }
+        $self->setBackupSet(\%cfg);
+
+        return 1;
+    }
+
+    return 0;
+}
+
+sub inheritBackupSetDstAutoCreation {
+    my $self = shift;
+    my $dataSet = shift;
+    my $dest = shift;
+    my $recurse = shift; # may be undef
+    my $inherit = shift; # may be undef
+
+    $self->zfs->dataSetExists($dataSet) or die "ERROR: dataset $dataSet does not exist\n";
+
+    $self->backupSets($self->zfs->getDataSetProperties($dataSet, $recurse, $inherit));
+
+    if (@{$self->backupSets}){
+        my %cfg = %{$self->backupSets->[0]};
+
+        if ( !($dest =~ /^dst_[^_]+$/) ) {
+            if ($cfg{'dst_' . $dest}) {
+                # User passed valid key of the destination config,
+                # convert to zfs attribute/perl struct name part
+                $dest = 'dst_' . $dest;
+            } elsif ($dest =~ /^DST:/) {
+                my $desttemp = $dest;
+                $desttemp =~ s/^DST:// ;
+                if ($cfg{'dst_' . $desttemp}) {
+                    # User passed valid key of the destination config,
+                    # convert to zfs attribute/perl struct name part
+                    $dest = 'dst_' . $desttemp;
+                }
+            }
+            # TODO: Else search by value of 'dst_N' as a "(remote@)dataset"
+        }
+
+        if ($cfg{$dest}) {
+            if ($cfg{$dest . '_autocreation'}) {
+                $cfg{$dest . '_autocreation'} = undef;
+            }
+        } else {
+            die "ERROR: dataset $dataSet backup plan does not have destination $dest\n";
+        }
+        $self->setBackupSet(\%cfg);
+
+        return 1;
+    }
+
+    return 0;
+}
+
 1;
 
 __END__


### PR DESCRIPTION
Builds on top of #636 ideas and is a step towards #503 hopefully.

At this time some optimization is possible: to only get dataset properties for the source tree once and walk the resulting array of hashes, instead of requesting props many times (once per child dataset as it does here, not unlike the `oracleMode` which trades one-by-one `zfs` commands handling vs. memory footprint of querying large chunks of names/properties on very populated ZFS trees). Still, as an MVP, this code already is functional (checked locally).