### PR TITLE
Portable makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ thirdparty/*
 !thirdparty/Makefile.am
 !thirdparty/cpanfile*snapshot
 *.tar.gz
+init/znapzend.freebsd
 init/znapzend.service
 init/znapzend.sysv
 init/znapzend.upstart

--- a/CHANGES
+++ b/CHANGES
@@ -5,8 +5,9 @@ znapzend (0.21.3) unstable; urgency=medium
   * Extended handling of "org.znapzend:enabled=off" setting for sub-trees: now if the same intermediate dataset declares "org.znapzend:recursive=on", the disablement of znapzend handling takes place for descendants as well (previously it had effect only exactly for datasets that set "org.znapzend:enabled=off" as a local ZFS property)
   * Fixed CI recipes and contents for spell-checker
   * Added rc-script and integration documentation for FreeBSD and similar platforms
+  * Converted configure.ac and numerous Makefile.am to avoid GNU Make syntax in favor of portability: tested with Solaris/illumos Sun make and with FreeBSD make
 
- -- Jim Klimov <jimklimov@gmail.com>  Tue, 9 Jan 2024 13:42:28 +0100
+ -- Jim Klimov <jimklimov@gmail.com>  Tue, 12 Mar 2024 13:42:28 +0100
 
 znapzend (0.21.2) unstable; urgency=medium
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ SUFFIXES = .1 .man .pm
 SUBDIRS = lib thirdparty debian
 
 BIN = bin/@PACKAGE@ bin/znapzendzetup bin/znapzendztatz
-PM :=  $(shell find $(srcdir)/lib/ -name "*.pm")
+PM  = @PERL_MODULES@
 MAN = man/znapzend.1 man/znapzendzetup.1 man/znapzendztatz.1
 POD = doc/znapzend.pod doc/znapzendzetup.pod doc/znapzendztatz.pod
 
@@ -22,8 +22,8 @@ EXTRA_DIST = VERSION COPYRIGHT README.md LICENSE CHANGES AUTHORS cpanfile $(BIN)
 	t/zfs t/znapzendzetup.t t/zpool \
 	debian/znapzend.links.in
 
-YEAR := $(shell date +%Y)
-DATE := $(shell date +%Y-%m-%d)
+YEAR = @CONFIG_YEAR@
+DATE = @CONFIG_DATE@
 
 if ENABLE_SVCINSTALL
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ you want to get a custom-made copy of znapzend, you will need a compiler and
 stuff to build some of the prerequisite perl modules into binary libraries
 for the target OS and architecture. For run-time you will need just perl.
 
+For a long time znapzend build required a GNU Make implementation. While this
+is no longer strictly the case, and at least Sun Make (as of OpenIndiana) and
+BSD Make (as of FreeBSD) are also known to work, the instructions below still
+suggest it as optional (if system-provided tools fail, fall back to `gmake`).
+
 The Git checkout includes a pregenerated `configure` script. For a rebuild
 of a checkout from scratch you may also want to `./bootstrap.sh` and then
 would need the autoconf/automake stack.
@@ -100,9 +105,11 @@ apt-get install autoconf carton
 
 * On Solaris 10 you may need the C compiler from Solaris Studio and gnu-make
 since the installed perl version is probably very old and you would likely
-have to build some dependency modules. The GNU make is needed instead of Sun
-make due to syntax differences. Notably you should reference it if you would
-boot-strap the code workspace from scratch:
+have to build some dependency modules. The GNU make may be needed instead
+of Sun make due to syntax standard differences over the years. Notably you
+could have to reference it if you would boot-strap the code workspace from
+scratch (and use later to `gmake install` as suggested by the `configure`
+script):
 ```sh
 MAKE=gmake ./bootstrap.sh
 ```
@@ -116,7 +123,7 @@ prior to running `configure`, e.g.:
 PERL=/opt/perl-32/bin/perl5.32.1 ./configure
 ```
 
-* On OmniOS/SmartOS you will need perl and gnu-make packages.
+* On OmniOS/SmartOS you will need perl and optionally gnu-make packages.
 
 * On macOS, if you have not already installed the Xcode command line tools,
 you can get them from the command line (Terminal app) with:

--- a/configure.ac
+++ b/configure.ac
@@ -26,6 +26,12 @@ AC_PATH_PROG(WGET, wget, no)
 AC_PATH_PROG(POD2MAN, pod2man, no)
 AC_PATH_PROG(RM, rm, no)
 
+AC_MSG_CHECKING([for CONFIG_YEAR and CONFIG_DATE])
+CONFIG_YEAR="`date +%Y`"
+CONFIG_DATE="`date +%Y-%m-%d`"
+AC_MSG_RESULT([got ${CONFIG_YEAR} and ${CONFIG_DATE} respectively])
+AC_SUBST(CONFIG_YEAR)
+AC_SUBST(CONFIG_DATE)
 
 AC_ARG_ENABLE([deb_build],
 AS_HELP_STRING([--enable-deb_build    Enable debian package build specifics]),
@@ -134,6 +140,7 @@ fi
 
 AC_PROG_GREP
 
+dnl We tried to make te Makefile.am syntax portable, but hiccups are possible
 AC_ARG_VAR(GMAKE,   [Path to local GNU Make binary])
 AC_PATH_PROGS(GMAKE, [gnumake gmake make])
 
@@ -141,7 +148,7 @@ AC_MSG_CHECKING([for gnu make availability])
 if  ( $GMAKE --version 2> /dev/null | $GREP GNU  > /dev/null 2>&1 );  then
     AC_MSG_RESULT([$GMAKE is GNU make])
 else
-    AC_MSG_ERROR([GNU make not found. Try setting the GMAKE environment variable.])
+    AC_MSG_WARN([GNU make not found, build recipes might fail. Try setting the GMAKE environment variable.])
 fi
 
 AC_ARG_ENABLE(pkgonly,
@@ -159,6 +166,21 @@ AC_MSG_RESULT(way to expensive!)
 
 AC_ARG_VAR(PERL5LIB,   [Colon separated list of perl library directories])
 AC_SUBST(PERL5LIB)
+
+AC_MSG_CHECKING([for PERL_MODULES])
+PERL_MODULES="`find "${srcdir}/lib/" -name "*.pm" | sed "s,^${srcdir}/,"'$(top_srcdir)/', | tr '\n' ' '`"
+AC_MSG_RESULT([${PERL_MODULES}])
+AC_SUBST(PERL_MODULES)
+
+AC_MSG_CHECKING([for PERL_CONFIG_VERSION])
+PERL_CONFIG_VERSION="`${PERL} -MConfig -e 'my $v = $Config{version}; $v =~ s/\.\d+$//; print $v;'`"
+AC_MSG_RESULT([${PERL_CONFIG_VERSION}])
+AC_SUBST(PERL_CONFIG_VERSION)
+
+AC_MSG_CHECKING([for PERL_THIRDPARTY_DIST cache])
+PERL_THIRDPARTY_DIST="`cd thirdparty && test -d cache && find cache -type f | tr '\n' ' '`"
+AS_IF([test x"${PERL_THIRDPARTY_DIST}" = x], [AC_MSG_RESULT([empty])], [AC_MSG_RESULT([populated])])
+AC_SUBST(PERL_THIRDPARTY_DIST)
 
 dnl Autotools default expansion of path settings results in further $variables
 dnl so for practical use in static configs this yarn has to be fully unrolled:
@@ -271,9 +293,10 @@ Settings:
   URL_CAT = $URL_CAT
   DEB_BUILD = $deb_build
 
-The Makefiles use GNU make functionality.
-Continue installation with
+The Makefiles should be portable to the best extent of our testing,
+but their recipes should most certainly succeed with GNU make.
+It is recommended that now you continue installation with
 
-  $GMAKE install
+  ${GMAKE:-make} install
 
 NOTES

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -1,7 +1,7 @@
 # Author: Tobi Oetiker <tobi@oetiker.ch>
 # License: Public Domain
 
-PM :=  $(shell find $(srcdir) -name "*.pm")
+PM = @PERL_MODULES@
 
 datadir = $(libdir)
 nobase_data_DATA = $(PM)

--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -2,14 +2,16 @@
 
 AUTOMAKE_OPTIONS =  foreign
 
-THIRDPARTY_DIR := $(shell pwd)
+THIRDPARTY_DIR = $(abs_builddir)
 
-# THIRDPARTY_DIST := $(shell test -d cache && find cache -type f )
-CPANSNAPV := cpanfile-$(shell $(PERL) -MConfig -e 'my $$v = $$Config{version}; $$v =~ s/\.\d+$$//; print $$v').snapshot
+#GNU# THIRDPARTY_DIST :+ $(shell test -d cache && find cache -type f )
+# THIRDPARTY_DIST = @PERL_THIRDPARTY_DIST@
+CPANSNAPV = cpanfile-@PERL_CONFIG_VERSION@.snapshot
 
 
 #EXTRA_DIST = $(THIRDPARTY_DIST) $(wildcard bin/cpanm)
-EXTRA_DIST = bin/cpanm $(wildcard cpanfile*snapshot)
+#EXTRA_DIST = bin/cpanm $(wildcard cpanfile*snapshot)
+EXTRA_DIST = bin/cpanm cpanfile*snapshot
 
 all-local: touch
 

--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -13,10 +13,9 @@ EXTRA_DIST = bin/cpanm $(wildcard cpanfile*snapshot)
 
 all-local: touch
 
-touch:  bin/cpanm $(CPANSNAPV)
+touch: bin/cpanm carton/bin/carton $(CPANSNAPV)
 	$(AM_V_at)echo "** Installing Dependencies using $(CPANSNAPV)"
 	cp $(CPANSNAPV) ../cpanfile.snapshot
-	test -x carton/bin/carton || PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton Date::Parse
 # if ever DBD::ODBC is compiled, make sure we get the utf8 version
 	PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install
 	$(AM_V_at)rm -f ../cpanfile.snapshot
@@ -27,10 +26,12 @@ bin/cpanm:
 	$(URL_CAT) https://cpanmin.us > bin/cpanm
 	$(AM_V_at)chmod 755 bin/cpanm
 
-$(CPANSNAPV): ../cpanfile
+carton/bin/carton: bin/cpanm
+	test -x carton/bin/carton || PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton Date::Parse
+
+$(CPANSNAPV): ../cpanfile carton/bin/carton
 	$(AM_V_at)echo "** Installing Dependencies using Carton install"
 	test -f $(CPANSNAPV) && cp $(CPANSNAPV) ../cpanfile.snapshot || true
-	test -x carton/bin/carton || PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton Date::Parse
 # if ever DBD::ODBC is compiled, make sure we get the utf8 version
 	PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install
 	mv ../cpanfile.snapshot $(CPANSNAPV)


### PR DESCRIPTION
Avoid GNUisms, allowing less fuss on BSD and illumos installs.

Checked with sequential and parallel builds/installs using Sun make on OpenIndiana 2023.10 and BSD make on FreeBSD 12.

````
:; git checkout -f && git clean -fdX && git status --ignored
:; ./bootstrap.sh && ./configure --prefix=/usr && make -j 8 && make -j 8 DESTDIR=/tmp/zzz install
````

"Screenshots" follow in posts below. To summarize them, comparing tests with GNU, Sun and BSD make this PR does not add regressions (or none were detected), and fixes parallel builds on top of that.

NOTE/question: @oetiker : Files like `thirdparty/cpanfile-5.38.snapshot` or `thirdparty/cpanfile-5.32.snapshot` (depending on OS perl version) appear and are explicitly not git-ignored nor cleaned away. One for 5.30 is in fact git-tracked. Should others be added?