### PR TITLE
Fix `make install` of Perl modules with a custom `DESTDIR` and/or `libdir`

### DIFF
--- a/.github/workflows/spelling/expect.txt
+++ b/.github/workflows/spelling/expect.txt
@@ -360,6 +360,7 @@ missingpool
 Mkbootstrap
 mkdir
 mkdirprog
+Mksymlists
 modled
 mojolicious
 Morbo
@@ -413,6 +414,7 @@ passphrase
 passwordless
 perl
 perldoc
+PEVANS
 pfexec
 php
 pid
@@ -436,7 +438,7 @@ posix
 prebuilt
 precmd
 prefork
-PREREQ
+prereq
 primarycache
 printf
 printsrc
@@ -470,6 +472,7 @@ resync
 RETVAL
 RHEL
 rindex
+RJBS
 rmcmd
 rmdir
 rmprog
@@ -516,6 +519,7 @@ sourcemissing
 sourcetype
 sourcing
 SPAMALOT
+spamming
 src
 srcame
 srcdir

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,3 @@
-0.22.1 2024-05-03 10:20:29 +0200 Tobias Oetiker <tobi@oetiker.ch>
-
   * Fix make install of Perl modules with a custom DESTDIR and/or libdir @jimklimov
 
 znapzend (0.22.0) unstable; urgency=medium

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,6 @@
 0.22.1 2024-05-03 10:20:29 +0200 Tobias Oetiker <tobi@oetiker.ch>
 
- -
+  * Fix make install of Perl modules with a custom DESTDIR and/or libdir @jimklimov
 
 znapzend (0.22.0) unstable; urgency=medium
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ SUFFIXES = .1 .man .pm
 SUBDIRS = lib thirdparty debian
 
 BIN = bin/@PACKAGE@ bin/znapzendzetup bin/znapzendztatz
-PM  = @PERL_MODULES@
+PM  = @PERL_MODULES_EXTRA_DIST@
 MAN = man/znapzend.1 man/znapzendzetup.1 man/znapzendztatz.1
 POD = doc/znapzend.pod doc/znapzendzetup.pod doc/znapzendztatz.pod
 

--- a/configure.ac
+++ b/configure.ac
@@ -167,8 +167,13 @@ AC_MSG_RESULT(way to expensive!)
 AC_ARG_VAR(PERL5LIB,   [Colon separated list of perl library directories])
 AC_SUBST(PERL5LIB)
 
+AC_MSG_CHECKING([for PERL_MODULES_EXTRA_DIST])
+PERL_MODULES_EXTRA_DIST="`find "${srcdir}/lib/" -name "*.pm" | sed "s,^${srcdir}/,"'$(top_srcdir)/', | tr '\n' ' '`"
+AC_MSG_RESULT([${PERL_MODULES_EXTRA_DIST}])
+AC_SUBST(PERL_MODULES_EXTRA_DIST)
+
 AC_MSG_CHECKING([for PERL_MODULES])
-PERL_MODULES="`find "${srcdir}/lib/" -name "*.pm" | sed "s,^${srcdir}/,"'$(top_srcdir)/', | tr '\n' ' '`"
+PERL_MODULES="`cd "${srcdir}/lib/" && ( find . -name "*.pm" | sed 's,^\./,,' | tr '\n' ' ' )`"
 AC_MSG_RESULT([${PERL_MODULES}])
 AC_SUBST(PERL_MODULES)
 

--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -48,7 +48,7 @@ update: $(CPANSNAPV)
 	$(AM_V_at)mv ../cpanfile.snapshot $(CPANSNAPV)
 
 clean-local:
-	ls -1 | grep -v Makefile | grep -v cpanfile |grep -v bin | xargs rm -rf
+	ls -1 | grep -v Makefile | grep -v cpanfile | grep -v bin | xargs rm -rf
 
 distclean-local:
 	ls -1 | grep -v Makefile | grep -v cpanfile | xargs rm -rf

--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -21,11 +21,15 @@ all-local: touch
 # It seems that neutering inheritance of parallel/nested "make" also helps;
 # alternately properly annotating such inheritance (`+` starting the line)
 # might also help. Trying both belts and suspenders here.
+# To add injury to insult, CPANM also uses `make` and is impacted by e.g.
+# the DESTDIR setting (if caller of znapzend `make` passes one) which may
+# also be made known via MAKEFLAGS (as of GNU Make).
 touch: bin/cpanm carton/bin/carton $(CPANSNAPV)
 	$(AM_V_at)echo "** Installing Dependencies using $(CPANSNAPV)"
 	cp $(CPANSNAPV) ../cpanfile.snapshot
 # if ever DBD::ODBC is compiled, make sure we get the utf8 version
-	+$(AM_V_at)TRIES=5 ; while test "$${TRIES}" -gt 0 ; do \
+	+$(AM_V_at)TRIES=5 ; unset DESTDIR || true ; unset MAKEFLAGS || true ; \
+	 while test "$${TRIES}" -gt 0 ; do \
 		PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install \
 		&& exit ; \
 		TRIES="`expr $${TRIES} - 1`" ; \
@@ -43,7 +47,8 @@ bin/cpanm:
 
 carton/bin/carton: bin/cpanm
 	$(AM_V_at)echo "** Installing/Checking Carton tool"
-	+$(AM_V_at)TRIES=5 ; while ! test -x carton/bin/carton ; do \
+	+$(AM_V_at)TRIES=5 ; unset DESTDIR || true ; unset MAKEFLAGS || true ; \
+	 while ! test -x carton/bin/carton ; do \
 		PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton Date::Parse \
 		&& exit ; \
 		TRIES="`expr $${TRIES} - 1`" ; \
@@ -57,7 +62,8 @@ $(CPANSNAPV): ../cpanfile carton/bin/carton
 	$(AM_V_at)echo "** Installing Dependencies using Carton install"
 	test -f $(CPANSNAPV) && cp $(CPANSNAPV) ../cpanfile.snapshot || true
 # if ever DBD::ODBC is compiled, make sure we get the utf8 version
-	+$(AM_V_at)TRIES=5 ; while test "$${TRIES}" -gt 0 ; do \
+	+$(AM_V_at)TRIES=5 ; unset DESTDIR || true ; unset MAKEFLAGS || true ; \
+	 while test "$${TRIES}" -gt 0 ; do \
 		PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install \
 		&& exit ; \
 		TRIES="`expr $${TRIES} - 1`" ; \
@@ -70,7 +76,8 @@ $(CPANSNAPV): ../cpanfile carton/bin/carton
 update: $(CPANSNAPV)
 	$(AM_V_at)echo "** Updating Dependencies using Carton update"
 	$(AM_V_at)cp $(CPANSNAPV) ../cpanfile.snapshot
-	+$(AM_V_at)TRIES=5 ; while test "$${TRIES}" -gt 0 ; do \
+	+$(AM_V_at)TRIES=5 ; unset DESTDIR || true ; unset MAKEFLAGS || true ; \
+	 while test "$${TRIES}" -gt 0 ; do \
 		$(AM_V_at)PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton update \
 		&& exit ; \
 		TRIES="`expr $${TRIES} - 1`" ; \

--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -24,11 +24,13 @@ touch: bin/cpanm carton/bin/carton $(CPANSNAPV)
 	$(AM_V_at)touch touch
 
 bin/cpanm:
+	$(AM_V_at)echo "** Installing CPANM tool"
 	$(AM_V_at)mkdir -p bin
 	$(URL_CAT) https://cpanmin.us > bin/cpanm
 	$(AM_V_at)chmod 755 bin/cpanm
 
 carton/bin/carton: bin/cpanm
+	$(AM_V_at)echo "** Installing/Checking Carton tool"
 	test -x carton/bin/carton || PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton Date::Parse
 
 $(CPANSNAPV): ../cpanfile carton/bin/carton

--- a/thirdparty/Makefile.am
+++ b/thirdparty/Makefile.am
@@ -15,11 +15,23 @@ EXTRA_DIST = bin/cpanm cpanfile*snapshot
 
 all-local: touch
 
+# NOTE: CPANM pulls a number of dependencies which seem to get installed in
+# parallel - in a random chaotic order (pun intended), so a few iterations
+# may be required - up to the amount of dependencies in the worst case.
+# It seems that neutering inheritance of parallel/nested "make" also helps;
+# alternately properly annotating such inheritance (`+` starting the line)
+# might also help. Trying both belts and suspenders here.
 touch: bin/cpanm carton/bin/carton $(CPANSNAPV)
 	$(AM_V_at)echo "** Installing Dependencies using $(CPANSNAPV)"
 	cp $(CPANSNAPV) ../cpanfile.snapshot
 # if ever DBD::ODBC is compiled, make sure we get the utf8 version
-	PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install
+	+$(AM_V_at)TRIES=5 ; while test "$${TRIES}" -gt 0 ; do \
+		PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install \
+		&& exit ; \
+		TRIES="`expr $${TRIES} - 1`" ; \
+		echo "** RETRY Installing Dependencies using $(CPANSNAPV) (attempts left: $${TRIES})" ; \
+		MAKEFLAGS="" ; export MAKEFLAGS ; \
+	done
 	$(AM_V_at)rm -f ../cpanfile.snapshot
 	$(AM_V_at)touch touch
 
@@ -31,20 +43,40 @@ bin/cpanm:
 
 carton/bin/carton: bin/cpanm
 	$(AM_V_at)echo "** Installing/Checking Carton tool"
-	test -x carton/bin/carton || PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton Date::Parse
+	+$(AM_V_at)TRIES=5 ; while ! test -x carton/bin/carton ; do \
+		PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) $(PERL) bin/cpanm -q --notest --local-lib-contained $(THIRDPARTY_DIR)/carton Carton Date::Parse \
+		&& exit ; \
+		TRIES="`expr $${TRIES} - 1`" ; \
+		if test "$${TRIES}" -lt 1 ; then exit 1 ; fi ; \
+		echo "** RETRY Installing/Checking Carton tool (attempts left: $${TRIES})" ; \
+		MAKEFLAGS="" ; export MAKEFLAGS ; \
+	done
+	test -x carton/bin/carton
 
 $(CPANSNAPV): ../cpanfile carton/bin/carton
 	$(AM_V_at)echo "** Installing Dependencies using Carton install"
 	test -f $(CPANSNAPV) && cp $(CPANSNAPV) ../cpanfile.snapshot || true
 # if ever DBD::ODBC is compiled, make sure we get the utf8 version
-	PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install
+	+$(AM_V_at)TRIES=5 ; while test "$${TRIES}" -gt 0 ; do \
+		PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) DBD_ODBC_UNICODE=1 PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton install \
+		&& exit ; \
+		TRIES="`expr $${TRIES} - 1`" ; \
+		echo "** RETRY Installing Dependencies using $(CPANSNAPV) (attempts left: $${TRIES})" ; \
+		MAKEFLAGS="" ; export MAKEFLAGS ; \
+	done
 	mv ../cpanfile.snapshot $(CPANSNAPV)
 	$(AM_V_at)touch touch
 
 update: $(CPANSNAPV)
 	$(AM_V_at)echo "** Updating Dependencies using Carton update"
 	$(AM_V_at)cp $(CPANSNAPV) ../cpanfile.snapshot
-	$(AM_V_at)PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton update
+	+$(AM_V_at)TRIES=5 ; while test "$${TRIES}" -gt 0 ; do \
+		$(AM_V_at)PERL_CPANM_OPT= PERL_CPANM_HOME=$(THIRDPARTY_DIR) PERL5LIB=$(THIRDPARTY_DIR)/carton/lib/perl5 PERL_CARTON_PATH=$(THIRDPARTY_DIR) $(PERL) $(THIRDPARTY_DIR)/carton/bin/carton update \
+		&& exit ; \
+		TRIES="`expr $${TRIES} - 1`" ; \
+		echo "** RETRY Installing Dependencies using $(CPANSNAPV) (attempts left: $${TRIES})" ; \
+		MAKEFLAGS="" ; export MAKEFLAGS ; \
+	done
 	$(AM_V_at)mv ../cpanfile.snapshot $(CPANSNAPV)
 
 clean-local:

--- a/thirdparty/cpanfile-5.22.4.snapshot
+++ b/thirdparty/cpanfile-5.22.4.snapshot
@@ -1,0 +1,312 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  ExtUtils-Config-0.008
+    pathname: L/LE/LEONT/ExtUtils-Config-0.008.tar.gz
+    provides:
+      ExtUtils::Config 0.008
+    requirements:
+      Data::Dumper 0
+      ExtUtils::MakeMaker 6.30
+      strict 0
+      warnings 0
+  ExtUtils-Helpers-0.026
+    pathname: L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz
+    provides:
+      ExtUtils::Helpers 0.026
+      ExtUtils::Helpers::Unix 0.026
+      ExtUtils::Helpers::VMS 0.026
+      ExtUtils::Helpers::Windows 0.026
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Spec::Functions 0
+      Text::ParseWords 3.24
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-InstallPaths-0.012
+    pathname: L/LE/LEONT/ExtUtils-InstallPaths-0.012.tar.gz
+    provides:
+      ExtUtils::InstallPaths 0.012
+    requirements:
+      Carp 0
+      ExtUtils::Config 0.002
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      perl 5.006
+      strict 0
+      warnings 0
+  IO-Pipely-0.005
+    pathname: R/RC/RCAPUTO/IO-Pipely-0.005.tar.gz
+    provides:
+      IO::Pipely 0.005
+    requirements:
+      Exporter 5.68
+      ExtUtils::MakeMaker 6.30
+      Fcntl 1.06
+      IO::Socket 1.31
+      Symbol 1.06
+      base 2.18
+      strict 0
+      warnings 0
+  Module-Build-0.4231
+    pathname: L/LE/LEONT/Module-Build-0.4231.tar.gz
+    provides:
+      Module::Build 0.4231
+      Module::Build::Base 0.4231
+      Module::Build::Compat 0.4231
+      Module::Build::Config 0.4231
+      Module::Build::Cookbook 0.4231
+      Module::Build::Dumper 0.4231
+      Module::Build::Notes 0.4231
+      Module::Build::PPMMaker 0.4231
+      Module::Build::Platform::Default 0.4231
+      Module::Build::Platform::MacOS 0.4231
+      Module::Build::Platform::Unix 0.4231
+      Module::Build::Platform::VMS 0.4231
+      Module::Build::Platform::VOS 0.4231
+      Module::Build::Platform::Windows 0.4231
+      Module::Build::Platform::aix 0.4231
+      Module::Build::Platform::cygwin 0.4231
+      Module::Build::Platform::darwin 0.4231
+      Module::Build::Platform::os2 0.4231
+      Module::Build::PodParser 0.4231
+    requirements:
+      CPAN::Meta 2.142060
+      Cwd 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0.27
+      ExtUtils::Install 0
+      ExtUtils::Manifest 0
+      ExtUtils::Mkbootstrap 0
+      ExtUtils::ParseXS 2.21
+      File::Basename 0
+      File::Compare 0
+      File::Copy 0
+      File::Find 0
+      File::Path 0
+      File::Spec 0.82
+      Getopt::Long 0
+      Module::Metadata 1.000002
+      Perl::OSType 1
+      Pod::Man 2.17
+      TAP::Harness 3.29
+      Text::Abbrev 0
+      Text::ParseWords 0
+      perl 5.006001
+      version 0.87
+  Module-Build-Tiny-0.039
+    pathname: L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz
+    provides:
+      Module::Build::Tiny 0.039
+    requirements:
+      CPAN::Meta 0
+      DynaLoader 0
+      Exporter 5.57
+      ExtUtils::CBuilder 0
+      ExtUtils::Config 0.003
+      ExtUtils::Helpers 0.020
+      ExtUtils::Install 0
+      ExtUtils::InstallPaths 0.002
+      ExtUtils::ParseXS 0
+      File::Basename 0
+      File::Find 0
+      File::Path 0
+      File::Spec::Functions 0
+      Getopt::Long 2.36
+      JSON::PP 2
+      Pod::Man 0
+      TAP::Harness::Env 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Mojo-IOLoop-Delay-8.76
+    pathname: J/JB/JBERGER/Mojo-IOLoop-Delay-8.76.tar.gz
+    provides:
+      Mojo::IOLoop::Delay 8.76
+    requirements:
+      Module::Build::Tiny 0.034
+      Mojolicious 0
+  Mojo-IOLoop-ForkCall-0.21
+    pathname: J/JB/JBERGER/Mojo-IOLoop-ForkCall-0.21.tar.gz
+    provides:
+      Mojo::IOLoop::ForkCall 0.21
+      Mojolicious::Plugin::ForkCall undef
+    requirements:
+      IO::Pipely 0
+      Module::Build 0.38
+      Mojo::IOLoop::Delay 0
+      Mojolicious 5.08
+      Perl::OSType 0
+  Mojolicious-9.19
+    pathname: S/SR/SRI/Mojolicious-9.19.tar.gz
+    provides:
+      Mojo undef
+      Mojo::Asset undef
+      Mojo::Asset::File undef
+      Mojo::Asset::Memory undef
+      Mojo::Base undef
+      Mojo::ByteStream undef
+      Mojo::Cache undef
+      Mojo::Collection undef
+      Mojo::Content undef
+      Mojo::Content::MultiPart undef
+      Mojo::Content::Single undef
+      Mojo::Cookie undef
+      Mojo::Cookie::Request undef
+      Mojo::Cookie::Response undef
+      Mojo::DOM undef
+      Mojo::DOM::CSS undef
+      Mojo::DOM::HTML undef
+      Mojo::Date undef
+      Mojo::DynamicMethods undef
+      Mojo::EventEmitter undef
+      Mojo::Exception undef
+      Mojo::File undef
+      Mojo::Headers undef
+      Mojo::HelloWorld undef
+      Mojo::Home undef
+      Mojo::IOLoop undef
+      Mojo::IOLoop::Client undef
+      Mojo::IOLoop::Server undef
+      Mojo::IOLoop::Stream undef
+      Mojo::IOLoop::Subprocess undef
+      Mojo::IOLoop::TLS undef
+      Mojo::JSON undef
+      Mojo::JSON::Pointer undef
+      Mojo::Loader undef
+      Mojo::Log undef
+      Mojo::Message undef
+      Mojo::Message::Request undef
+      Mojo::Message::Response undef
+      Mojo::Parameters undef
+      Mojo::Path undef
+      Mojo::Promise undef
+      Mojo::Reactor undef
+      Mojo::Reactor::EV undef
+      Mojo::Reactor::Poll undef
+      Mojo::Server undef
+      Mojo::Server::CGI undef
+      Mojo::Server::Daemon undef
+      Mojo::Server::Hypnotoad undef
+      Mojo::Server::Morbo undef
+      Mojo::Server::Morbo::Backend undef
+      Mojo::Server::Morbo::Backend::Poll undef
+      Mojo::Server::PSGI undef
+      Mojo::Server::Prefork undef
+      Mojo::Template undef
+      Mojo::Transaction undef
+      Mojo::Transaction::HTTP undef
+      Mojo::Transaction::WebSocket undef
+      Mojo::URL undef
+      Mojo::Upload undef
+      Mojo::UserAgent undef
+      Mojo::UserAgent::CookieJar undef
+      Mojo::UserAgent::Proxy undef
+      Mojo::UserAgent::Server undef
+      Mojo::UserAgent::Transactor undef
+      Mojo::Util undef
+      Mojo::WebSocket undef
+      Mojolicious 9.19
+      Mojolicious::Command undef
+      Mojolicious::Command::Author::cpanify undef
+      Mojolicious::Command::Author::generate undef
+      Mojolicious::Command::Author::generate::app undef
+      Mojolicious::Command::Author::generate::dockerfile undef
+      Mojolicious::Command::Author::generate::lite_app undef
+      Mojolicious::Command::Author::generate::makefile undef
+      Mojolicious::Command::Author::generate::plugin undef
+      Mojolicious::Command::Author::inflate undef
+      Mojolicious::Command::cgi undef
+      Mojolicious::Command::daemon undef
+      Mojolicious::Command::eval undef
+      Mojolicious::Command::get undef
+      Mojolicious::Command::prefork undef
+      Mojolicious::Command::psgi undef
+      Mojolicious::Command::routes undef
+      Mojolicious::Command::version undef
+      Mojolicious::Commands undef
+      Mojolicious::Controller undef
+      Mojolicious::Lite undef
+      Mojolicious::Plugin undef
+      Mojolicious::Plugin::Config undef
+      Mojolicious::Plugin::DefaultHelpers undef
+      Mojolicious::Plugin::EPLRenderer undef
+      Mojolicious::Plugin::EPRenderer undef
+      Mojolicious::Plugin::HeaderCondition undef
+      Mojolicious::Plugin::JSONConfig undef
+      Mojolicious::Plugin::Mount undef
+      Mojolicious::Plugin::NotYAMLConfig undef
+      Mojolicious::Plugin::TagHelpers undef
+      Mojolicious::Plugins undef
+      Mojolicious::Renderer undef
+      Mojolicious::Routes undef
+      Mojolicious::Routes::Match undef
+      Mojolicious::Routes::Pattern undef
+      Mojolicious::Routes::Route undef
+      Mojolicious::Sessions undef
+      Mojolicious::Static undef
+      Mojolicious::Types undef
+      Mojolicious::Validator undef
+      Mojolicious::Validator::Validation undef
+      Test::Mojo undef
+      ojo undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      IO::Socket::IP 0.37
+      Sub::Util 1.41
+      perl 5.016
+  Scalar-List-Utils-1.56
+    pathname: P/PE/PEVANS/Scalar-List-Utils-1.56.tar.gz
+    provides:
+      List::Util 1.56
+      List::Util::XS 1.56
+      Scalar::Util 1.56
+      Sub::Util 1.56
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006
+  Sub-Uplevel-0.2800
+    pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz
+    provides:
+      Sub::Uplevel 0.2800
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Test-Exception-0.43
+    pathname: E/EX/EXODIST/Test-Exception-0.43.tar.gz
+    provides:
+      Test::Exception 0.43
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Sub::Uplevel 0.18
+      Test::Builder 0.7
+      Test::Builder::Tester 1.07
+      Test::Harness 2.03
+      base 0
+      perl 5.006001
+      strict 0
+      warnings 0
+  Test-SharedFork-0.35
+    pathname: E/EX/EXODIST/Test-SharedFork-0.35.tar.gz
+    provides:
+      Test::SharedFork 0.35
+      Test::SharedFork::Array undef
+      Test::SharedFork::Scalar undef
+      Test::SharedFork::Store undef
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      File::Temp 0
+      Test::Builder 0.32
+      Test::Builder::Module 0
+      Test::More 0.88
+      perl 5.008_001

--- a/thirdparty/cpanfile-5.34.0.snapshot
+++ b/thirdparty/cpanfile-5.34.0.snapshot
@@ -1,0 +1,341 @@
+# carton snapshot format: version 1.0
+DISTRIBUTIONS
+  CPAN-Meta-Requirements-2.143
+    pathname: R/RJ/RJBS/CPAN-Meta-Requirements-2.143.tar.gz
+    provides:
+      CPAN::Meta::Requirements 2.143
+      CPAN::Meta::Requirements::Range 2.143
+    requirements:
+      B 0
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      perl 5.010000
+      strict 0
+      version 0.88
+      warnings 0
+  CPAN-Requirements-Dynamic-0.001
+    pathname: L/LE/LEONT/CPAN-Requirements-Dynamic-0.001.tar.gz
+    provides:
+      CPAN::Requirements::Dynamic 0.001
+    requirements:
+      CPAN::Meta::Prereqs 0
+      CPAN::Meta::Requirements::Range 0
+      Carp 0
+      ExtUtils::Config 0
+      ExtUtils::HasCompiler 0
+      ExtUtils::MakeMaker 0
+      IPC::Cmd 0
+      Module::Metadata 0
+      Parse::CPAN::Meta 0
+      Perl::OSType 0
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-Config-0.009
+    pathname: L/LE/LEONT/ExtUtils-Config-0.009.tar.gz
+    provides:
+      ExtUtils::Config 0.009
+      ExtUtils::Config::MakeMaker 0.009
+    requirements:
+      Data::Dumper 0
+      ExtUtils::MakeMaker 0
+      ExtUtils::MakeMaker::Config 0
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-HasCompiler-0.025
+    pathname: L/LE/LEONT/ExtUtils-HasCompiler-0.025.tar.gz
+    provides:
+      ExtUtils::HasCompiler 0.025
+    requirements:
+      Carp 0
+      DynaLoader 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      ExtUtils::Mksymlists 0
+      File::Basename 0
+      File::Spec::Functions 0
+      File::Temp 0
+      base 0
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-Helpers-0.026
+    pathname: L/LE/LEONT/ExtUtils-Helpers-0.026.tar.gz
+    provides:
+      ExtUtils::Helpers 0.026
+      ExtUtils::Helpers::Unix 0.026
+      ExtUtils::Helpers::VMS 0.026
+      ExtUtils::Helpers::Windows 0.026
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Spec::Functions 0
+      Text::ParseWords 3.24
+      perl 5.006
+      strict 0
+      warnings 0
+  ExtUtils-InstallPaths-0.013
+    pathname: L/LE/LEONT/ExtUtils-InstallPaths-0.013.tar.gz
+    provides:
+      ExtUtils::InstallPaths 0.013
+    requirements:
+      Carp 0
+      ExtUtils::Config 0.002
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      perl 5.006
+      strict 0
+      warnings 0
+  IO-Pipely-0.006
+    pathname: R/RC/RCAPUTO/IO-Pipely-0.006.tar.gz
+    provides:
+      IO::Pipely 0.006
+    requirements:
+      Exporter 5.72
+      ExtUtils::MakeMaker 0
+      Fcntl 1.13
+      IO::Socket 1.38
+      Symbol 1.08
+      base 0
+      perl 5.004
+      strict 0
+      warnings 0
+  Module-Build-0.4234
+    pathname: L/LE/LEONT/Module-Build-0.4234.tar.gz
+    provides:
+      Module::Build 0.4234
+      Module::Build::Base 0.4234
+      Module::Build::Compat 0.4234
+      Module::Build::Config 0.4234
+      Module::Build::Cookbook 0.4234
+      Module::Build::Dumper 0.4234
+      Module::Build::Notes 0.4234
+      Module::Build::PPMMaker 0.4234
+      Module::Build::Platform::Default 0.4234
+      Module::Build::Platform::MacOS 0.4234
+      Module::Build::Platform::Unix 0.4234
+      Module::Build::Platform::VMS 0.4234
+      Module::Build::Platform::VOS 0.4234
+      Module::Build::Platform::Windows 0.4234
+      Module::Build::Platform::aix 0.4234
+      Module::Build::Platform::cygwin 0.4234
+      Module::Build::Platform::darwin 0.4234
+      Module::Build::Platform::os2 0.4234
+      Module::Build::PodParser 0.4234
+    requirements:
+      CPAN::Meta 2.142060
+      Cwd 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0.27
+      ExtUtils::Install 0
+      ExtUtils::Manifest 0
+      ExtUtils::Mkbootstrap 0
+      ExtUtils::ParseXS 2.21
+      File::Basename 0
+      File::Compare 0
+      File::Copy 0
+      File::Find 0
+      File::Path 0
+      File::Spec 0.82
+      Getopt::Long 0
+      Module::Metadata 1.000002
+      Perl::OSType 1
+      TAP::Harness 3.29
+      Text::Abbrev 0
+      Text::ParseWords 0
+      perl 5.006001
+      version 0.87
+  Module-Build-Tiny-0.048
+    pathname: L/LE/LEONT/Module-Build-Tiny-0.048.tar.gz
+    provides:
+      Module::Build::Tiny 0.048
+    requirements:
+      CPAN::Meta 0
+      CPAN::Requirements::Dynamic 0
+      DynaLoader 0
+      Exporter 5.57
+      ExtUtils::CBuilder 0
+      ExtUtils::Config 0.003
+      ExtUtils::Helpers 0.020
+      ExtUtils::Install 0
+      ExtUtils::InstallPaths 0.002
+      ExtUtils::ParseXS 0
+      File::Basename 0
+      File::Find 0
+      File::Path 0
+      File::Spec::Functions 0
+      Getopt::Long 2.36
+      JSON::PP 2
+      Pod::Man 0
+      TAP::Harness::Env 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Mojo-IOLoop-Delay-8.76
+    pathname: J/JB/JBERGER/Mojo-IOLoop-Delay-8.76.tar.gz
+    provides:
+      Mojo::IOLoop::Delay 8.76
+    requirements:
+      Module::Build::Tiny 0.034
+      Mojolicious 0
+  Mojo-IOLoop-ForkCall-0.21
+    pathname: J/JB/JBERGER/Mojo-IOLoop-ForkCall-0.21.tar.gz
+    provides:
+      Mojo::IOLoop::ForkCall 0.21
+      Mojolicious::Plugin::ForkCall undef
+    requirements:
+      IO::Pipely 0
+      Module::Build 0.38
+      Mojo::IOLoop::Delay 0
+      Mojolicious 5.08
+      Perl::OSType 0
+  Mojolicious-9.37
+    pathname: S/SR/SRI/Mojolicious-9.37.tar.gz
+    provides:
+      Mojo undef
+      Mojo::Asset undef
+      Mojo::Asset::File undef
+      Mojo::Asset::Memory undef
+      Mojo::Base undef
+      Mojo::BaseUtil undef
+      Mojo::ByteStream undef
+      Mojo::Cache undef
+      Mojo::Collection undef
+      Mojo::Content undef
+      Mojo::Content::MultiPart undef
+      Mojo::Content::Single undef
+      Mojo::Cookie undef
+      Mojo::Cookie::Request undef
+      Mojo::Cookie::Response undef
+      Mojo::DOM undef
+      Mojo::DOM::CSS undef
+      Mojo::DOM::HTML undef
+      Mojo::Date undef
+      Mojo::DynamicMethods undef
+      Mojo::EventEmitter undef
+      Mojo::Exception undef
+      Mojo::File undef
+      Mojo::Headers undef
+      Mojo::HelloWorld undef
+      Mojo::Home undef
+      Mojo::IOLoop undef
+      Mojo::IOLoop::Client undef
+      Mojo::IOLoop::Server undef
+      Mojo::IOLoop::Stream undef
+      Mojo::IOLoop::Subprocess undef
+      Mojo::IOLoop::TLS undef
+      Mojo::JSON undef
+      Mojo::JSON::Pointer undef
+      Mojo::Loader undef
+      Mojo::Log undef
+      Mojo::Message undef
+      Mojo::Message::Request undef
+      Mojo::Message::Response undef
+      Mojo::Parameters undef
+      Mojo::Path undef
+      Mojo::Promise undef
+      Mojo::Reactor undef
+      Mojo::Reactor::EV undef
+      Mojo::Reactor::Poll undef
+      Mojo::Server undef
+      Mojo::Server::CGI undef
+      Mojo::Server::Daemon undef
+      Mojo::Server::Hypnotoad undef
+      Mojo::Server::Morbo undef
+      Mojo::Server::Morbo::Backend undef
+      Mojo::Server::Morbo::Backend::Poll undef
+      Mojo::Server::PSGI undef
+      Mojo::Server::Prefork undef
+      Mojo::Template undef
+      Mojo::Transaction undef
+      Mojo::Transaction::HTTP undef
+      Mojo::Transaction::WebSocket undef
+      Mojo::URL undef
+      Mojo::Upload undef
+      Mojo::UserAgent undef
+      Mojo::UserAgent::CookieJar undef
+      Mojo::UserAgent::Proxy undef
+      Mojo::UserAgent::Server undef
+      Mojo::UserAgent::Transactor undef
+      Mojo::Util undef
+      Mojo::WebSocket undef
+      Mojolicious 9.37
+      Mojolicious::Command undef
+      Mojolicious::Command::Author::cpanify undef
+      Mojolicious::Command::Author::generate undef
+      Mojolicious::Command::Author::generate::app undef
+      Mojolicious::Command::Author::generate::dockerfile undef
+      Mojolicious::Command::Author::generate::lite_app undef
+      Mojolicious::Command::Author::generate::makefile undef
+      Mojolicious::Command::Author::generate::plugin undef
+      Mojolicious::Command::Author::inflate undef
+      Mojolicious::Command::cgi undef
+      Mojolicious::Command::daemon undef
+      Mojolicious::Command::eval undef
+      Mojolicious::Command::get undef
+      Mojolicious::Command::prefork undef
+      Mojolicious::Command::psgi undef
+      Mojolicious::Command::routes undef
+      Mojolicious::Command::version undef
+      Mojolicious::Commands undef
+      Mojolicious::Controller undef
+      Mojolicious::Lite undef
+      Mojolicious::Plugin undef
+      Mojolicious::Plugin::Config undef
+      Mojolicious::Plugin::DefaultHelpers undef
+      Mojolicious::Plugin::EPLRenderer undef
+      Mojolicious::Plugin::EPRenderer undef
+      Mojolicious::Plugin::HeaderCondition undef
+      Mojolicious::Plugin::JSONConfig undef
+      Mojolicious::Plugin::Mount undef
+      Mojolicious::Plugin::NotYAMLConfig undef
+      Mojolicious::Plugin::TagHelpers undef
+      Mojolicious::Plugins undef
+      Mojolicious::Renderer undef
+      Mojolicious::Routes undef
+      Mojolicious::Routes::Match undef
+      Mojolicious::Routes::Pattern undef
+      Mojolicious::Routes::Route undef
+      Mojolicious::Sessions undef
+      Mojolicious::Static undef
+      Mojolicious::Types undef
+      Mojolicious::Validator undef
+      Mojolicious::Validator::Validation undef
+      Test::Mojo undef
+      ojo undef
+    requirements:
+      ExtUtils::MakeMaker 0
+      IO::Socket::IP 0.37
+      Sub::Util 1.41
+      perl 5.016
+  Sub-Uplevel-0.2800
+    pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.2800.tar.gz
+    provides:
+      Sub::Uplevel 0.2800
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.17
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Test-Exception-0.43
+    pathname: E/EX/EXODIST/Test-Exception-0.43.tar.gz
+    provides:
+      Test::Exception 0.43
+    requirements:
+      Carp 0
+      Exporter 0
+      ExtUtils::MakeMaker 0
+      Sub::Uplevel 0.18
+      Test::Builder 0.7
+      Test::Builder::Tester 1.07
+      Test::Harness 2.03
+      base 0
+      perl 5.006001
+      strict 0
+      warnings 0


### PR DESCRIPTION
Closes: #646
Closes: #651

Checked fixed with GNU Make on Ubuntu 22, illumos make on OpenIndiana, BSD make on FreeBSD 12.

See "screenshot" at https://github.com/oetiker/znapzend/issues/646#issuecomment-2133971445

