### PR TITLE
Rename `lib/inheritLevels.pm` to `lib/ZnapZend/InheritLevels.pm`…

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,9 @@
     resource file during build -- @jimklimov
   * Fix `make install` of Perl modules with a custom `DESTDIR` and/or when
     applying `configure --libdir=...` requirements -- @jimklimov
+  * Renamed `lib/inheritLevels.pm` to `lib/ZnapZend/InheritLevels.pm`, in
+    order to minimize confusion (especially when targeting OS-wide Perl
+    module installations) -- @jimklimov
   * Applied same markup style to older CHANGES logged entries -- @jimklimov
 
 znapzend (0.22.0) unstable; urgency=medium

--- a/lib/ZnapZend/InheritLevels.pm
+++ b/lib/ZnapZend/InheritLevels.pm
@@ -1,5 +1,6 @@
-package inheritLevels;
+package ZnapZend::InheritLevels;
 # Note: classes made by Class::Struct may not be sub-namespaced
+# (UPDATE: comment might be valid at least in older Perl versions?)
 
 use Class::Struct;
 
@@ -10,7 +11,7 @@ use Class::Struct;
 ### For "usual" datasets (filesystem,volume) `zfs` returns the
 ### properties inherited from higher level datasets; but for
 ### snapshots it only returns the same - not from higher snaps.
-struct ('inheritLevels' => {
+struct ('ZnapZend::InheritLevels' => {
     zfs_local => '$', # set to ask for properties defined locally in dataset
     zfs_inherit => '$', # set to ask for properties inherited from higher datasets
     zfs_received => '$', # set to ask for properties received during "zfs send|recv" (no-op for now, mentioned for completeness)
@@ -59,9 +60,9 @@ sub getInhMode {
 sub reset {
     # Without args, just resets all fields back to undef so they can be
     # re-assigned later. With an arg tries to import a legacy setting by
-    # number or string, or copy from another instance of inheritLevels.
+    # number or string, or copy from another instance of InheritLevels.
     my $self = shift;
-    
+
     $self->zfs_local(undef);
     $self->zfs_inherit(undef);
     $self->zfs_received(undef);
@@ -69,7 +70,7 @@ sub reset {
     if (@_) {
         my $arg = shift;
         # Assign from legacy values
-        if ($arg->isa('inheritLevels')) {
+        if ($arg->isa('ZnapZend::InheritLevels') or $arg->isa('InheritLevels')) {
             $self->zfs_local($arg->zfs_local);
             $self->zfs_inherit($arg->zfs_inherit);
             $self->zfs_received($arg->zfs_received);
@@ -89,7 +90,7 @@ sub reset {
         } elsif (!defined($arg) or $arg == undef) {
             1; # No-op, keep fields undef
         } else {
-            warn "inheritLevels::reset() got unsupported argument '$arg'\n";
+            warn "ZnapZend::InheritLevels::reset() got unsupported argument '$arg'\n";
             return 0;
         }
     }
@@ -102,14 +103,14 @@ __END__
 
 =head1 NAME
 
-inheritLevels - helper struct for various options of ZFS property inheritance
+ZnapZend::InheritLevels - helper struct for various options of ZFS property inheritance
 
 =head1 SYNOPSIS
 
-use inheritLevels;
+use ZnapZend::InheritLevels;
 use ZnapZend::ZFS;
 ...
-my $inherit = new inheritLevels;
+my $inherit = new ZnapZend::InheritLevels;
 $inherit->zfs_local(1);
 $inherit->zfs_inherit(1);
 my $properties = $self->getSnapshotProperties($snapshot, $recurse, $inherit, @dstSyncedProps);

--- a/lib/ZnapZend/InheritLevels.pm
+++ b/lib/ZnapZend/InheritLevels.pm
@@ -70,7 +70,7 @@ sub reset {
     if (@_) {
         my $arg = shift;
         # Assign from legacy values
-        if ($arg->isa('ZnapZend::InheritLevels') or $arg->isa('InheritLevels')) {
+        if ($arg->isa('ZnapZend::InheritLevels')) {
             $self->zfs_local($arg->zfs_local);
             $self->zfs_inherit($arg->zfs_inherit);
             $self->zfs_received($arg->zfs_received);

--- a/lib/ZnapZend/InheritLevels.pm
+++ b/lib/ZnapZend/InheritLevels.pm
@@ -110,7 +110,7 @@ ZnapZend::InheritLevels - helper struct for various options of ZFS property inhe
 use ZnapZend::InheritLevels;
 use ZnapZend::ZFS;
 ...
-my $inherit = new ZnapZend::InheritLevels;
+my $inherit = ZnapZend::InheritLevels->new;
 $inherit->zfs_local(1);
 $inherit->zfs_inherit(1);
 my $properties = $self->getSnapshotProperties($snapshot, $recurse, $inherit, @dstSyncedProps);

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -4,7 +4,7 @@ use Mojo::Base -base;
 use Mojo::Exception;
 use Mojo::IOLoop::Subprocess;
 use Data::Dumper;
-use inheritLevels;
+use ZnapZend::InheritLevels;
 
 ### attributes ###
 has debug           => sub { 0 };
@@ -547,13 +547,13 @@ sub mostRecentCommonSnapshot {
     # deletion of "protected" last-known-synced snapshots, we consider both
     # local and inherited values of the dst_X_synced flag, if present.
     # See definition of recognized $inherit values for this context in
-    # getSnapshotProperties() code and struct inheritLevels.
+    # getSnapshotProperties() code and struct ZnapZend::InheritLevels.
     my $inherit = shift; # May be not passed => undef
     if (!defined($inherit)) {
         # We leave defined but invalid values of $inherit to
         # getSnapshotProperties() to figure out and complain,
         # but for this routine's purposes set a specific default.
-        $inherit = new inheritLevels;
+        $inherit = new ZnapZend::InheritLevels;
         $inherit->zfs_local(1);
         $inherit->zfs_inherit(1);
         $inherit->snapshot_recurse_parent(1);
@@ -1300,8 +1300,8 @@ sub getSnapshotProperties {
     #   1 = local + inherit as defined by zfs
     #   2 = local + recurse into parent that has same snapname
     #   3 = local + inherit as defined by zfs + recurse into parent
-    # See struct inheritLevels for reusable definitions.
-    my $inherit = shift; # May be not passed => undef => will make a new inheritLevels instance below
+    # See struct ZnapZend::InheritLevels for reusable definitions.
+    my $inherit = shift; # May be not passed => undef => will make a new InheritLevels instance below
 
     # Limit the request to `zfs get` to only pick out certain properties
     # and save time not-processing stuff the caller will ignore?..
@@ -1321,13 +1321,13 @@ sub getSnapshotProperties {
     }
 
     if (!defined($inherit)) {
-        $inherit = new inheritLevels;
+        $inherit = new ZnapZend::InheritLevels;
         $inherit->zfs_local(1);
     } else {
         # Data type check
-        if ( ! $inherit->isa('inheritLevels') ) {
-            $self->zLog->warn("getSnapshotProperties(): inherit argument is not an instance of struct inheritLevels");
-            my $newInherit = new inheritLevels;
+        if ( ! ($inherit->isa('ZnapZend::InheritLevels') or $inherit->isa('InheritLevels')) ) {
+            $self->zLog->warn("getSnapshotProperties(): inherit argument is not an instance of struct ZnapZend::InheritLevels");
+            my $newInherit = new ZnapZend::InheritLevels;
             if (!$newInherit->reset($inherit)) {
                 # caller DID set something, so set a default... local_zfsinherit
                 $newInherit->zfs_local(1);
@@ -1459,7 +1459,7 @@ sub getSnapshotProperties {
                 # Go up to root of the pool, without recursing into other children
                 # of the parent datasets/snapshots, and without inheriting stuff
                 # that is not locally defined properties of a parent (or its parent).
-                my $inherit_local_recurseparent = new inheritLevels;
+                my $inherit_local_recurseparent = new ZnapZend::InheritLevels;
                 $inherit_local_recurseparent->snapshot_recurse_parent(1);
                 $inherit_local_recurseparent->zfs_local(1);
                 my $parentProperties = $self->getSnapshotProperties($parentSnapshot, 0, $inherit_local_recurseparent, $propnames);

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -1325,7 +1325,7 @@ sub getSnapshotProperties {
         $inherit->zfs_local(1);
     } else {
         # Data type check
-        if ( ! ($inherit->isa('ZnapZend::InheritLevels') or $inherit->isa('InheritLevels')) ) {
+        if ( ! ($inherit->isa('ZnapZend::InheritLevels')) ) {
             $self->zLog->warn("getSnapshotProperties(): inherit argument is not an instance of struct ZnapZend::InheritLevels");
             my $newInherit = ZnapZend::InheritLevels->new;
             if (!$newInherit->reset($inherit)) {

--- a/lib/ZnapZend/ZFS.pm
+++ b/lib/ZnapZend/ZFS.pm
@@ -553,7 +553,7 @@ sub mostRecentCommonSnapshot {
         # We leave defined but invalid values of $inherit to
         # getSnapshotProperties() to figure out and complain,
         # but for this routine's purposes set a specific default.
-        $inherit = new ZnapZend::InheritLevels;
+        $inherit = ZnapZend::InheritLevels->new;
         $inherit->zfs_local(1);
         $inherit->zfs_inherit(1);
         $inherit->snapshot_recurse_parent(1);
@@ -1321,13 +1321,13 @@ sub getSnapshotProperties {
     }
 
     if (!defined($inherit)) {
-        $inherit = new ZnapZend::InheritLevels;
+        $inherit = ZnapZend::InheritLevels->new;
         $inherit->zfs_local(1);
     } else {
         # Data type check
         if ( ! ($inherit->isa('ZnapZend::InheritLevels') or $inherit->isa('InheritLevels')) ) {
             $self->zLog->warn("getSnapshotProperties(): inherit argument is not an instance of struct ZnapZend::InheritLevels");
-            my $newInherit = new ZnapZend::InheritLevels;
+            my $newInherit = ZnapZend::InheritLevels->new;
             if (!$newInherit->reset($inherit)) {
                 # caller DID set something, so set a default... local_zfsinherit
                 $newInherit->zfs_local(1);
@@ -1459,7 +1459,7 @@ sub getSnapshotProperties {
                 # Go up to root of the pool, without recursing into other children
                 # of the parent datasets/snapshots, and without inheriting stuff
                 # that is not locally defined properties of a parent (or its parent).
-                my $inherit_local_recurseparent = new ZnapZend::InheritLevels;
+                my $inherit_local_recurseparent = ZnapZend::InheritLevels->new;
                 $inherit_local_recurseparent->snapshot_recurse_parent(1);
                 $inherit_local_recurseparent->zfs_local(1);
                 my $parentProperties = $self->getSnapshotProperties($parentSnapshot, 0, $inherit_local_recurseparent, $propnames);


### PR DESCRIPTION
…to minimize confusion

From issue #646 discussion follow-up

Needs diligent testing (CI and practical) to make sure the expected `inherit` functionality is still handled correctly. For local testing to progress, this effort led to PR #654 first, and existing tests did catch some syntax issues that were fixed over a few iterations of this PR's preparation.