### PR TITLE
Update znapzend.default with autoCreation enabled

### DIFF
--- a/init/znapzend.default
+++ b/init/znapzend.default
@@ -1,2 +1,2 @@
 # Command line options for znapzend
-ZNAPZENDOPTIONS=""
+ZNAPZENDOPTIONS="--autoCreation"


### PR DESCRIPTION
I don't see any reason to not have this enabled