### PR TITLE
Add Ubuntu 26.04 to deb package build matrix

### DIFF
--- a/.github/workflows/build_deb_packages.yaml
+++ b/.github/workflows/build_deb_packages.yaml
@@ -29,6 +29,8 @@ jobs:
             version: 22.04
           - distribution: ubuntu
             version: 24.04
+          - distribution: ubuntu
+            version: 26.04
 
     runs-on: ubuntu-latest
     name: Build package for ${{ matrix.distribution }} ${{ matrix.version }}


### PR DESCRIPTION
Adds Ubuntu 24.04 (Noble) and 26.04 to the `.deb` package release build matrix in `.github/workflows/build_deb_packages.yaml`.

The matrix previously stopped at Ubuntu 22.04, leaving a gap for the current LTS (24.04) and the upcoming 26.04 release.