### PR TITLE
deb: accept upstream OpenZFS userland (openzfsutils) as dependency alternative

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,5 +6,5 @@ Build-Depends: build-essential, debhelper (>= 9), perl
 
 Package: znapzend
 Architecture: any
-Depends: ${shlibs:Depends}, perl, zfsutils-linux
+Depends: ${shlibs:Depends}, perl, zfsutils-linux | openzfsutils
 Description: ZnapZend is a ZFS centric backup tool to create snapshots and send them to backup locations


### PR DESCRIPTION
Systems running the upstream OpenZFS userland (`make native-deb` → `openzfs-zfsutils`, which `Conflicts: zfsutils-linux` and `Provides: openzfsutils`) currently cannot co-install znapzend: apt removes znapzend when the upstream zfs packages are installed, and reinstalling znapzend would force the upstream userland out again.

This is a real-world situation right now: Ubuntu 26.04 ships kernel 7.0 with zfs 2.4.1, a combination OpenZFS itself flags as experimental (`ZFS: Using ZFS with kernel 7.0.0-27-generic is EXPERIMENTAL and SERIOUS DATA LOSS may occur`), so running the upstream 2.4.3 packages is the sane configuration there — and it currently costs you znapzend.

Fix: `Depends: ... zfsutils-linux | openzfsutils`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)