### PR TITLE
Fix Release workflow: docker tag never expanded (fails every master push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           MY_KEY: ${{ secrets.DOCKER_HUB_USERNAME }}
         if: "${{ env.MY_KEY != '' }}"
-        run: echo "::set-output name=defined::true"
+        run: echo "defined=true" >> "$GITHUB_OUTPUT"
 
   docker:
     name: Build and publish Docker container
@@ -28,12 +28,14 @@ jobs:
     needs: [check-secret]
     if: needs.check-secret.outputs.my-key == 'true'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Login to image registry
       run: docker login -u '${{ secrets.DOCKER_HUB_USERNAME }}' -p '${{ secrets.DOCKER_HUB_PASSWORD }}'
     - name: Build runtime image
-      run: docker build --target runtime -t '${{ github.repository }}:${GITHUB_REF##*/}' .
+      # tag is the branch or tag name (single quotes would keep the shell
+      # from expanding GITHUB_REF and produce an invalid docker tag)
+      run: docker build --target runtime -t "${{ github.repository }}:${GITHUB_REF##*/}" .
     - name: Run test within image
       run: docker build --target test .
     - name: Push runtime image
-      run: docker push '${{ github.repository }}:${GITHUB_REF##*/}'
+      run: docker push "${{ github.repository }}:${GITHUB_REF##*/}"


### PR DESCRIPTION
The docker build/push steps quote the image tag in single quotes:

```yaml
run: docker build --target runtime -t '${{ github.repository }}:${GITHUB_REF##*/}' .
```

The `${{ }}` part is substituted by Actions, but `${GITHUB_REF##*/}` is shell parameter expansion — and single quotes suppress it, so docker receives the literal string and fails with `invalid tag ... invalid reference format`. Every Release run since #680 has failed this way (see the workflow history).

- Use double quotes so the branch/tag name is expanded into the image tag.
- Replace deprecated `::set-output` with `$GITHUB_OUTPUT` (GitHub is about to disable the old command).
- Bump `actions/checkout` v2 → v4 (Node deprecation warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)