### PR TITLE
Fix release: drop EOL Debian 10 / Ubuntu 18.04 deb builds, retry apt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,17 +144,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Debian 10 (buster) and Ubuntu 18.04 (bionic) are intentionally
+        # omitted: both are EOL. Buster's apt repos moved to archive.debian.org
+        # (404 on the normal mirror) and bionic's glibc 2.27 is too old to run
+        # the node-based GitHub actions (actions/checkout needs glibc >= 2.28).
         include:
-          - distribution: debian
-            version: 10
           - distribution: debian
             version: 11
           - distribution: debian
             version: 12
           - distribution: debian
             version: 13
-          - distribution: ubuntu
-            version: 18.04
           - distribution: ubuntu
             version: 20.04
           - distribution: ubuntu
@@ -178,7 +178,12 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.tag }}
       - name: Install OS requirements
-        run: apt-get update && apt-get -yq install perl unzip autoconf carton debhelper pkg-config
+        # Retry apt so a transient mirror hiccup (connection reset mid-fetch)
+        # doesn't fail the whole release; --fix-missing re-fetches stragglers.
+        run: |
+          apt-get -o Acquire::Retries=3 update
+          apt-get -o Acquire::Retries=3 -yq --fix-missing install \
+            perl unzip autoconf carton debhelper pkg-config
       - name: CPAN cache
         id: cpan_cache
         uses: actions/cache@v4

--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,10 @@
 #
 znapzend (0.23.7) UNRELEASED; urgency=medium
 
+  * Dropped .deb package builds for the EOL Debian 10 (buster) and
+    Ubuntu 18.04 (bionic) releases, which can no longer be built in CI
+    (buster's apt repos are archived; bionic's glibc is too old for the
+    GitHub Actions runtime).
 
  -- github-actions[bot] <github-actions[bot]@users.noreply.github.com>  Mon, 06 Jul 2026 19:52:39 +0000
 


### PR DESCRIPTION
## Problem

The **v0.23.6** release run ([logs](https://github.com/oetiker/znapzend/actions/runs/28818962024)) succeeded overall — tarball, ghcr image, and 6 debs published — but three deb-matrix jobs failed:

| Job | Cause | Nature |
|-----|-------|--------|
| debian 10 (buster) | `404` — apt repos moved to `archive.debian.org` | EOL, permanent |
| ubuntu 18.04 (bionic) | `node: GLIBC_2.28 not found` — glibc 2.27 can't run node24 actions | EOL, unfixable |
| debian 11 | `Connection reset by peer` fetching a `.deb` | transient flake |

## Fix

- **Drop Debian 10 and Ubuntu 18.04** from the release deb matrix. Both are EOL; Ubuntu 18.04 is unfixable (even node20 needs glibc ≥ 2.28, which bionic lacks). Matrix keeps Debian 11/12/13 + Ubuntu 20.04/22.04/24.04/26.04.
- **Harden apt** with `Acquire::Retries=3` + `--fix-missing` so transient mirror resets (the Debian 11 failure) self-heal instead of failing a release.
- CHANGES bullet documenting the dropped package targets.

## Not addressed here
v0.23.6's release is already published and is only missing the debian10/debian11/ubuntu18.04 debs. Debian 11's can be backfilled by re-running that one job if wanted; the two EOL ones can't be built at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)